### PR TITLE
Refactor book detail flow to MVVM and clean up activity handling

### DIFF
--- a/.agents/mcp_config.json
+++ b/.agents/mcp_config.json
@@ -1,0 +1,7 @@
+{
+	"mcpServers": {
+		"xcode": {
+			"command": "/Applications/Xcode.app/Contents/Developer/usr/bin/mcpbridge"
+		}
+	}
+}

--- a/.agents/memory-bank/activeContext.md
+++ b/.agents/memory-bank/activeContext.md
@@ -5,7 +5,7 @@ The primary development focus is executing Phase 1 of the SwiftUI MVVM Refactori
 
 ## Recent Changes & Decisions
 - **Development Environment Migration:** Transitioning the project to an agent-first development workflow using the Google Antigravity CLI.
-- **Architectural Shift (MVVM):** Decided to transition from a single monolithic `@EnvironmentObject var modelData` to modular `@StateObject` ViewModels for complex views.
+- **Architectural Shift (MVVM):** Transitioning from a single monolithic `@EnvironmentObject var modelData` to modular `@StateObject` ViewModels for complex views.
 - **Context Guardrails:** Established the `.agents/memory-bank` directory to provide strict architectural guidelines, preventing subagents from hallucinating or deviating from the Swift Package Manager / SwiftUI architecture.
 - **MCP Integration:** Moved Xcode toolchain configurations to `.agents/mcp_config.json` to allow the Antigravity CLI to autonomously interact with `xcodebuild` and the iOS Simulator.
 
@@ -19,11 +19,11 @@ The primary development focus is executing Phase 1 of the SwiftUI MVVM Refactori
 - [x] 7. Decoupled `ModelData` from `BookDetailView`'s state presentation stack, book conversion, and metadata status, proxying them through `BookDetailViewModel`. Unit tests added and verified.
 - [x] 8. Migrated presentation state variables (`presentingReadingSheet`, `presentingPreviewSheet`, `activityListViewPresenting`, `readingPositionHistoryViewPresenting`) from `BookDetailView` to `BookDetailViewModel`, utilizing custom Binding wrappers in property observers.
 - [x] 9. Decoupled `BookDetailView` entirely from `@EnvironmentObject var modelData`, utilizing dependency injection of `ModelData.shared` inside the ViewModel.
+- [x] 10. Enforced MVVM architecture on Reading Position views (`ReadingPositionHistoryView` and `ReadingPositionDetailView`), decoupling them from `ModelData` and Realm queries via `ReadingPositionHistoryViewModel` and `ReadingPositionDetailViewModel`.
 
 ## Next Steps
-- [ ] 10. Apply similar MVVM componentization to other large views (e.g., `LibraryInfoBookListView`).
-- [ ] 11. Decouple `CalibreServerService` and remaining `ModelData` dependencies.
-
+- [ ] 11. Apply similar MVVM componentization to other large views (e.g., `LibraryInfoBookListView`).
+- [ ] 12. Decouple `CalibreServerService` and remaining `ModelData` dependencies.
 
 ## Active Constraints
 - **Do NOT** introduce CocoaPods or modify workspace files; the project relies entirely on Swift Package Manager.

--- a/.agents/memory-bank/activeContext.md
+++ b/.agents/memory-bank/activeContext.md
@@ -14,9 +14,12 @@ The primary development focus is executing Phase 1 of the SwiftUI MVVM Refactori
 [COMPLETED] 2. Break down the massive `BookDetailView.swift` (800+ lines) into smaller, manageable subcomponents (`BookDetailSubviews.swift`).
 [COMPLETED] 3. Replace direct `ModelData` network calls inside `BookDetailView` with unidirectional data flow via `BookDetailViewModel`.
 [COMPLETED] 4. Compile the project in the terminal using `xcodebuild` to ensure the SwiftUI refactoring doesn't break the build and unit tests pass.
+[COMPLETED] 5. Successfully decoupled `ModelData` from all `BookDetailView` subviews (`BookCoverView`, `BookMetadataSection`, `BookConnectivitySection`, `BookFormatList`, `BookProgressSection`) by passing state through `BookDetailViewModel`. Unit test regressions have been resolved.
 
-[NEXT] 5. Apply similar MVVM componentization to other large views (e.g., `LibraryInfoBookListView`).
-[NEXT] 6. Decouple `CalibreServerService` and `BookDownloadManager` from `ModelData`.
+[COMPLETED] 6. Decoupled `BookDownloadManager` from `BookDetailView` and `BookDetailSubviews` by mapping `activeDownloads` into `BookDetailViewModel` using Combine. Tests pass.
+
+[NEXT] 6. Apply similar MVVM componentization to other large views (e.g., `LibraryInfoBookListView`).
+[NEXT] 7. Decouple `CalibreServerService` and remaining `ModelData` dependencies.
 ## Active Constraints
 - **Do NOT** introduce CocoaPods or modify workspace files; the project relies entirely on Swift Package Manager.
 - **Decoupling Goal:** Views should minimize direct dependency on `ModelData` for network operations; logic should reside in dedicated ViewModels.

--- a/.agents/memory-bank/activeContext.md
+++ b/.agents/memory-bank/activeContext.md
@@ -10,12 +10,13 @@ The primary development focus is executing Phase 1 of the SwiftUI MVVM Refactori
 - **MCP Integration:** Moved Xcode toolchain configurations to `.agents/mcp_config.json` to allow the Antigravity CLI to autonomously interact with `xcodebuild` and the iOS Simulator.
 
 ## Active Tasks
-1. Expand `BookDetailViewModel.swift` to handle all data fetching (metadata, manifest) and UI state variables currently trapped in `BookDetailView.swift`.
-2. Break down the massive `BookDetailView.swift` (800+ lines) into smaller, manageable subcomponents (e.g., `BookCoverView`, `BookMetadataSection`).
-3. Replace direct `ModelData` network calls inside `BookDetailView` with unidirectional data flow via `BookDetailViewModel`.
-4. Compile the project in the terminal using `xcodebuild` to ensure the SwiftUI refactoring doesn't break the build.
-5. Apply similar MVVM componentization to other large views (e.g., `LibraryInfoBookListView`).
+[COMPLETED] 1. Expand `BookDetailViewModel.swift` to handle all data fetching (metadata, manifest) and UI state variables currently trapped in `BookDetailView.swift`.
+[COMPLETED] 2. Break down the massive `BookDetailView.swift` (800+ lines) into smaller, manageable subcomponents (`BookDetailSubviews.swift`).
+[COMPLETED] 3. Replace direct `ModelData` network calls inside `BookDetailView` with unidirectional data flow via `BookDetailViewModel`.
+[COMPLETED] 4. Compile the project in the terminal using `xcodebuild` to ensure the SwiftUI refactoring doesn't break the build and unit tests pass.
 
+[NEXT] 5. Apply similar MVVM componentization to other large views (e.g., `LibraryInfoBookListView`).
+[NEXT] 6. Decouple `CalibreServerService` and `BookDownloadManager` from `ModelData`.
 ## Active Constraints
 - **Do NOT** introduce CocoaPods or modify workspace files; the project relies entirely on Swift Package Manager.
 - **Decoupling Goal:** Views should minimize direct dependency on `ModelData` for network operations; logic should reside in dedicated ViewModels.

--- a/.agents/memory-bank/activeContext.md
+++ b/.agents/memory-bank/activeContext.md
@@ -10,16 +10,18 @@ The primary development focus is executing Phase 1 of the SwiftUI MVVM Refactori
 - **MCP Integration:** Moved Xcode toolchain configurations to `.agents/mcp_config.json` to allow the Antigravity CLI to autonomously interact with `xcodebuild` and the iOS Simulator.
 
 ## Active Tasks
-[COMPLETED] 1. Expand `BookDetailViewModel.swift` to handle all data fetching (metadata, manifest) and UI state variables currently trapped in `BookDetailView.swift`.
-[COMPLETED] 2. Break down the massive `BookDetailView.swift` (800+ lines) into smaller, manageable subcomponents (`BookDetailSubviews.swift`).
-[COMPLETED] 3. Replace direct `ModelData` network calls inside `BookDetailView` with unidirectional data flow via `BookDetailViewModel`.
-[COMPLETED] 4. Compile the project in the terminal using `xcodebuild` to ensure the SwiftUI refactoring doesn't break the build and unit tests pass.
-[COMPLETED] 5. Successfully decoupled `ModelData` from all `BookDetailView` subviews (`BookCoverView`, `BookMetadataSection`, `BookConnectivitySection`, `BookFormatList`, `BookProgressSection`) by passing state through `BookDetailViewModel`. Unit test regressions have been resolved.
+- [x] 1. Expand `BookDetailViewModel.swift` to handle all data fetching (metadata, manifest) and UI state variables currently trapped in `BookDetailView.swift`.
+- [x] 2. Break down the massive `BookDetailView.swift` (800+ lines) into smaller, manageable subcomponents (`BookDetailSubviews.swift`).
+- [x] 3. Replace direct `ModelData` network calls inside `BookDetailView` with unidirectional data flow via `BookDetailViewModel`.
+- [x] 4. Compile the project in the terminal using `xcodebuild` to ensure the SwiftUI refactoring doesn't break the build and unit tests pass.
+- [x] 5. Successfully decoupled `ModelData` from all `BookDetailView` subviews (`BookCoverView`, `BookMetadataSection`, `BookConnectivitySection`, `BookFormatList`, `BookProgressSection`) by passing state through `BookDetailViewModel`.
+- [x] 6. Decoupled `BookDownloadManager` from `BookDetailView` and `BookDetailSubviews` by mapping `activeDownloads` into `BookDetailViewModel` using Combine.
+- [x] 7. Decoupled `ModelData` from `BookDetailView`'s state presentation stack, book conversion, and metadata status, proxying them through `BookDetailViewModel`. Unit tests added and verified.
 
-[COMPLETED] 6. Decoupled `BookDownloadManager` from `BookDetailView` and `BookDetailSubviews` by mapping `activeDownloads` into `BookDetailViewModel` using Combine. Tests pass.
+## Next Steps
+- [ ] 8. Apply similar MVVM componentization to other large views (e.g., `LibraryInfoBookListView`).
+- [ ] 9. Decouple `CalibreServerService` and remaining `ModelData` dependencies.
 
-[NEXT] 6. Apply similar MVVM componentization to other large views (e.g., `LibraryInfoBookListView`).
-[NEXT] 7. Decouple `CalibreServerService` and remaining `ModelData` dependencies.
 ## Active Constraints
 - **Do NOT** introduce CocoaPods or modify workspace files; the project relies entirely on Swift Package Manager.
 - **Decoupling Goal:** Views should minimize direct dependency on `ModelData` for network operations; logic should reside in dedicated ViewModels.

--- a/.agents/memory-bank/activeContext.md
+++ b/.agents/memory-bank/activeContext.md
@@ -20,10 +20,12 @@ The primary development focus is executing Phase 1 of the SwiftUI MVVM Refactori
 - [x] 8. Migrated presentation state variables (`presentingReadingSheet`, `presentingPreviewSheet`, `activityListViewPresenting`, `readingPositionHistoryViewPresenting`) from `BookDetailView` to `BookDetailViewModel`, utilizing custom Binding wrappers in property observers.
 - [x] 9. Decoupled `BookDetailView` entirely from `@EnvironmentObject var modelData`, utilizing dependency injection of `ModelData.shared` inside the ViewModel.
 - [x] 10. Enforced MVVM architecture on Reading Position views (`ReadingPositionHistoryView` and `ReadingPositionDetailView`), decoupling them from `ModelData` and Realm queries via `ReadingPositionHistoryViewModel` and `ReadingPositionDetailViewModel`.
+- [x] 11. Enforced MVVM architecture on Activity Log views (`ActivityList` and `ActivityDetailView`), extracting Realm queries and resolution logic to `ActivityListViewModel` and exposing plain `ActivityLogUIEntry` structures.
+- [x] 12. Fixed the `recent-shelf-updater` background thread Realm concurrency crash by caching `realmPerf` via thread-local storage (`Thread.current.threadDictionary`).
 
 ## Next Steps
-- [ ] 11. Apply similar MVVM componentization to other large views (e.g., `LibraryInfoBookListView`).
-- [ ] 12. Decouple `CalibreServerService` and remaining `ModelData` dependencies.
+- [ ] 13. Apply similar MVVM componentization to other large views (e.g., `LibraryInfoBookListView`).
+- [ ] 14. Decouple `CalibreServerService` and remaining `ModelData` dependencies.
 
 ## Active Constraints
 - **Do NOT** introduce CocoaPods or modify workspace files; the project relies entirely on Swift Package Manager.

--- a/.agents/memory-bank/activeContext.md
+++ b/.agents/memory-bank/activeContext.md
@@ -1,0 +1,21 @@
+# Active Context
+
+## Current Focus
+The primary development focus is to use the Readium engine to optimize the loading performance of PDF bookmarks. 
+
+## Recent Changes & Decisions
+- **Development Environment Migration:** Transitioning the project to an agent-first development workflow using the Google Antigravity CLI.
+- **Context Guardrails:** Established the `.agents/memory-bank` directory to provide strict architectural guidelines, preventing subagents from hallucinating or deviating from the Swift Package Manager / SwiftUI architecture.
+- **MCP Integration:** Moved Xcode toolchain configurations to `.agents/mcp_config.json` to allow the Antigravity CLI to autonomously interact with `xcodebuild` and the iOS Simulator.
+
+## Active Tasks
+1. Analyze the current PDF bookmark parsing and loading mechanisms within the `YetAnotherEBookReader/Readium/` integration and associated PDF model files (`Models/BookAnnotation.swift`, `YabrPDFModel.swift`).
+2. Identify performance bottlenecks occurring during the rendering of large PDF bookmark trees via the Readium 3.8 SDK.
+3. Implement performance optimizations (e.g., lazy loading, background threading via `DispatchQueue` or Combine) without blocking the main UI thread.
+4. Compile the project in the terminal using the command: `xcodebuild build -scheme YetAnotherEBookReader -destination 'platform=iOS Simulator,name=iPhone 15 Pro,OS=latest'` to verify build integrity.
+5. Verify the performance improvements in the iOS Simulator.
+
+## Active Constraints
+- **Do NOT** introduce CocoaPods or modify workspace files; the project relies entirely on Swift Package Manager.
+- All UI state changes must be routed through the existing `ModelData` implementation using Combine.
+

--- a/.agents/memory-bank/activeContext.md
+++ b/.agents/memory-bank/activeContext.md
@@ -18,10 +18,12 @@ The primary development focus is executing Phase 1 of the SwiftUI MVVM Refactori
 - [x] 6. Decoupled `BookDownloadManager` from `BookDetailView` and `BookDetailSubviews` by mapping `activeDownloads` into `BookDetailViewModel` using Combine.
 - [x] 7. Decoupled `ModelData` from `BookDetailView`'s state presentation stack, book conversion, and metadata status, proxying them through `BookDetailViewModel`. Unit tests added and verified.
 - [x] 8. Migrated presentation state variables (`presentingReadingSheet`, `presentingPreviewSheet`, `activityListViewPresenting`, `readingPositionHistoryViewPresenting`) from `BookDetailView` to `BookDetailViewModel`, utilizing custom Binding wrappers in property observers.
+- [x] 9. Decoupled `BookDetailView` entirely from `@EnvironmentObject var modelData`, utilizing dependency injection of `ModelData.shared` inside the ViewModel.
 
 ## Next Steps
-- [ ] 9. Apply similar MVVM componentization to other large views (e.g., `LibraryInfoBookListView`).
-- [ ] 10. Decouple `CalibreServerService` and remaining `ModelData` dependencies.
+- [ ] 10. Apply similar MVVM componentization to other large views (e.g., `LibraryInfoBookListView`).
+- [ ] 11. Decouple `CalibreServerService` and remaining `ModelData` dependencies.
+
 
 ## Active Constraints
 - **Do NOT** introduce CocoaPods or modify workspace files; the project relies entirely on Swift Package Manager.

--- a/.agents/memory-bank/activeContext.md
+++ b/.agents/memory-bank/activeContext.md
@@ -1,21 +1,21 @@
 # Active Context
 
 ## Current Focus
-The primary development focus is to use the Readium engine to optimize the loading performance of PDF bookmarks. 
+The primary development focus is executing Phase 1 of the SwiftUI MVVM Refactoring Plan. We are systematically decoupling massive SwiftUI views from the `ModelData` "God Object" and introducing dedicated ViewModels to handle business logic and state.
 
 ## Recent Changes & Decisions
 - **Development Environment Migration:** Transitioning the project to an agent-first development workflow using the Google Antigravity CLI.
+- **Architectural Shift (MVVM):** Decided to transition from a single monolithic `@EnvironmentObject var modelData` to modular `@StateObject` ViewModels for complex views.
 - **Context Guardrails:** Established the `.agents/memory-bank` directory to provide strict architectural guidelines, preventing subagents from hallucinating or deviating from the Swift Package Manager / SwiftUI architecture.
 - **MCP Integration:** Moved Xcode toolchain configurations to `.agents/mcp_config.json` to allow the Antigravity CLI to autonomously interact with `xcodebuild` and the iOS Simulator.
 
 ## Active Tasks
-1. Analyze the current PDF bookmark parsing and loading mechanisms within the `YetAnotherEBookReader/Readium/` integration and associated PDF model files (`Models/BookAnnotation.swift`, `YabrPDFModel.swift`).
-2. Identify performance bottlenecks occurring during the rendering of large PDF bookmark trees via the Readium 3.8 SDK.
-3. Implement performance optimizations (e.g., lazy loading, background threading via `DispatchQueue` or Combine) without blocking the main UI thread.
-4. Compile the project in the terminal using the command: `xcodebuild build -scheme YetAnotherEBookReader -destination 'platform=iOS Simulator,name=iPhone 15 Pro,OS=latest'` to verify build integrity.
-5. Verify the performance improvements in the iOS Simulator.
+1. Expand `BookDetailViewModel.swift` to handle all data fetching (metadata, manifest) and UI state variables currently trapped in `BookDetailView.swift`.
+2. Break down the massive `BookDetailView.swift` (800+ lines) into smaller, manageable subcomponents (e.g., `BookCoverView`, `BookMetadataSection`).
+3. Replace direct `ModelData` network calls inside `BookDetailView` with unidirectional data flow via `BookDetailViewModel`.
+4. Compile the project in the terminal using `xcodebuild` to ensure the SwiftUI refactoring doesn't break the build.
+5. Apply similar MVVM componentization to other large views (e.g., `LibraryInfoBookListView`).
 
 ## Active Constraints
 - **Do NOT** introduce CocoaPods or modify workspace files; the project relies entirely on Swift Package Manager.
-- All UI state changes must be routed through the existing `ModelData` implementation using Combine.
-
+- **Decoupling Goal:** Views should minimize direct dependency on `ModelData` for network operations; logic should reside in dedicated ViewModels.

--- a/.agents/memory-bank/activeContext.md
+++ b/.agents/memory-bank/activeContext.md
@@ -17,10 +17,11 @@ The primary development focus is executing Phase 1 of the SwiftUI MVVM Refactori
 - [x] 5. Successfully decoupled `ModelData` from all `BookDetailView` subviews (`BookCoverView`, `BookMetadataSection`, `BookConnectivitySection`, `BookFormatList`, `BookProgressSection`) by passing state through `BookDetailViewModel`.
 - [x] 6. Decoupled `BookDownloadManager` from `BookDetailView` and `BookDetailSubviews` by mapping `activeDownloads` into `BookDetailViewModel` using Combine.
 - [x] 7. Decoupled `ModelData` from `BookDetailView`'s state presentation stack, book conversion, and metadata status, proxying them through `BookDetailViewModel`. Unit tests added and verified.
+- [x] 8. Migrated presentation state variables (`presentingReadingSheet`, `presentingPreviewSheet`, `activityListViewPresenting`, `readingPositionHistoryViewPresenting`) from `BookDetailView` to `BookDetailViewModel`, utilizing custom Binding wrappers in property observers.
 
 ## Next Steps
-- [ ] 8. Apply similar MVVM componentization to other large views (e.g., `LibraryInfoBookListView`).
-- [ ] 9. Decouple `CalibreServerService` and remaining `ModelData` dependencies.
+- [ ] 9. Apply similar MVVM componentization to other large views (e.g., `LibraryInfoBookListView`).
+- [ ] 10. Decouple `CalibreServerService` and remaining `ModelData` dependencies.
 
 ## Active Constraints
 - **Do NOT** introduce CocoaPods or modify workspace files; the project relies entirely on Swift Package Manager.

--- a/.agents/memory-bank/productContext.md
+++ b/.agents/memory-bank/productContext.md
@@ -1,0 +1,18 @@
+# Product Context: YetAnotherEBookReader (D.S.Reader)
+
+## Purpose
+YetAnotherEBookReader (publicly known as D.S.Reader) is a versatile, high-performance, and modern e-book reader designed for iOS (15.0+) and macOS (12.0+ via Catalyst). Its primary goal is to provide native rendering for EPUB, PDF, and CBZ formats while maintaining deep and seamless integration with Calibre content servers for cloud synchronization of libraries and reading progress.
+
+## Core Features
+- **Multi-Format Native Rendering:** Supports EPUB, PDF, and CBZ using the Readium 3.8 R2 SDK and FolioReaderKit (for legacy EPUBs).
+- **Calibre Sync:** Full integration with Calibre content servers to sync metadata, shelves, and cross-device reading positions.
+- **Modernized & Accessible UI:** Unified SwiftUI-based settings, dynamic margins, theme support (Light, Dark, Sepia), RTL (Right-to-Left) progression support, volume key paging, and VoiceOver optimizations.
+
+## Architecture & Tech Stack
+- **UI Frameworks:** SwiftUI (iOS 15+) and UIKit.
+- **State Management:** Centralized via `@StateObject` `ModelData` (`Models/ModelData.swift`), which manages application state, database initialization, and server connectivity. All app-wide state is accessed using `@EnvironmentObject var modelData: ModelData`.
+- **Persistence:** RealmSwift is strictly used for storing metadata, highlights, shelves, and reading progress.
+- **Networking & Assets:** `CalibreServerService` handles API interactions with Calibre servers. GCDWebServer serves local book assets to web-based reader views, while Kingfisher handles efficient image caching. 
+- **Concurrency:** Asynchronous operations extensively use Combine and `DispatchQueue` for non-blocking I/O and server requests.
+- **Dependency Management:** Pure Swift Package Manager (SPM) only; the project deliberately avoids CocoaPods or Xcode Workspaces.
+

--- a/.agents/memory-bank/productContext.md
+++ b/.agents/memory-bank/productContext.md
@@ -10,9 +10,8 @@ YetAnotherEBookReader (publicly known as D.S.Reader) is a versatile, high-perfor
 
 ## Architecture & Tech Stack
 - **UI Frameworks:** SwiftUI (iOS 15+) and UIKit.
-- **State Management:** Centralized via `@StateObject` `ModelData` (`Models/ModelData.swift`), which manages application state, database initialization, and server connectivity. All app-wide state is accessed using `@EnvironmentObject var modelData: ModelData`.
+- **State Management (Migrating to MVVM):** Historically centralized via `@StateObject` `ModelData` (`Models/ModelData.swift`), the project is currently migrating to a modular MVVM architecture. Massive views are being decoupled from `ModelData` in favor of dedicated ViewModels (e.g., `BookDetailViewModel`).
 - **Persistence:** RealmSwift is strictly used for storing metadata, highlights, shelves, and reading progress.
 - **Networking & Assets:** `CalibreServerService` handles API interactions with Calibre servers. GCDWebServer serves local book assets to web-based reader views, while Kingfisher handles efficient image caching. 
 - **Concurrency:** Asynchronous operations extensively use Combine and `DispatchQueue` for non-blocking I/O and server requests.
 - **Dependency Management:** Pure Swift Package Manager (SPM) only; the project deliberately avoids CocoaPods or Xcode Workspaces.
-

--- a/.agents/memory-bank/refactoring-context.md
+++ b/.agents/memory-bank/refactoring-context.md
@@ -1,0 +1,31 @@
+# Refactoring Analysis Context
+
+## Date: 2026-06-06
+
+## Summary
+A comprehensive architectural analysis was performed on the entire YetAnotherEBookReader codebase (28,702 Swift lines, 88 files).
+
+## Key Findings
+
+### Top 5 Critical Issues (P0)
+1. **ModelData God Object** (2180 lines, 18 @Published properties) — needs splitting into 5-7 service classes
+2. **Zero test coverage** — only 1 placeholder test exists
+3. **RealmSwift leaked into 36 files** including 20+ view files — needs Repository pattern
+
+### Architecture Stats
+- Schema version: 137 (very high migration debt)
+- `CalibreLibrarySearchManager` is the class in `CalibreBrowser.swift` (2137 lines)
+- FolioReaderKit used via 7 files, Readium via 10 files (ReadiumShared + ReadiumNavigator)
+- Reading position save/restore is triplicated across 3 reader engines
+- V2 migration started but only covers search (156 lines vs V1's 2137 lines)
+
+### Refactoring Plan
+Full plan at: `~/.gemini/antigravity/brain/6899dc7b-d068-4b64-98ae-678c877182ce/REFACTOR_PLAN.md`
+
+### Key Class Names (for future reference)
+- `ModelData` — central state (Models/ModelData.swift)
+- `CalibreLibrarySearchManager` — search/browse engine (Models/CalibreBrowser/CalibreBrowser.swift)
+- `CalibreServerService` — network API (Network/CalibreServerService.swift)
+- `BookDownloadManager` — download management (Network/BookDownloadManager.swift)
+- `YabrPDFViewController` — PDF reader (Views/PDFView/YabrPDFViewController.swift, 1716 lines)
+- `YabrReadiumReaderViewController` — Readium reader (Views/ReadiumView/, 747 lines)

--- a/.agents/memory-bank/unified-search-analysis.md
+++ b/.agents/memory-bank/unified-search-analysis.md
@@ -1,0 +1,42 @@
+# Unified Search Subsystem Analysis
+
+## Date: 2026-06-06
+
+## Core Discovery: 7-Stage Reactive Pipeline
+
+The `CalibreUnifiedSearchObject` is generated through a 7-stage Combine-based reactive pipeline
+within `CalibreLibrarySearchManager` (CalibreBrowser.swift, 2137 lines):
+
+1. **Create/Find** — `retrieveUnifiedSearchObject()` (L1587-1639)
+2. **Register Observer** — `registerCacheUnifiedSearchObject()` (L617-701) with 5-second delay
+3. **Search Refresh** — `registerSearchRefreshReceiver()` (L778-818)
+4. **Search Request** — `registerSearchRequestReceiver()` (L820-914), crosses 4 DispatchQueues
+5. **Network/Realm Search** — `searchLibraryBooks()` (L2005-2134), HTTP or offline Realm
+6. **Metadata Fetch** — `registerMetadataRequestReceiver()` (L916-1018)
+7. **K-way Merge** — `mergeBookListsNew()` (L1658-1757), uses sorted array (should be heap)
+
+## Key Data Models
+- `CalibreLibrarySearchObject` — per-library search criteria + `sources: Map<serverUrl, ValueObject>`
+- `CalibreLibrarySearchValueObject` — per-source results with `bookIds` and `books` lists
+- `CalibreUnifiedSearchObject` — merged result with `unifiedOffsets`, `books`, `limitNumber`
+- `CalibreUnifiedOffsets` — per-library merge state (offset, beenCutOff, beenConsumed)
+- `CalibreUnifiedSearchRuntime` — non-persisted indexMap and notification token
+
+## 6 Consumer Views
+1. LibraryInfoBookListView (@ObservedRealmObject)
+2. LibraryInfoBookListInfoView (@ObservedRealmObject)
+3. LibraryInfoBookRow (@ObservedRealmObject)
+4. LibraryInfoView.ViewModel (@Published)
+5. SectionShelfController (dict)
+6. YabrShelfDataModel.CategoryObject (optional)
+
+## Critical Issues Found
+1. K-way merge uses O(K·logK) sort instead of O(logK) heap
+2. Merge runs inside Realm write transaction (long lock)
+3. `fatalError` in production code (L1670)
+4. `try!` scattered 20+ places
+5. retrieveUnifiedSearchObject called from 3 different threads without synchronization
+6. cutOff in one library aborts entire merge (L1744 `break`)
+
+## Artifact
+Full analysis: `unified_search_analysis.md`

--- a/.agents/memory-bank/unified_search_analysis.md
+++ b/.agents/memory-bank/unified_search_analysis.md
@@ -1,0 +1,861 @@
+# CalibreUnifiedSearchObject 深度分析与现代化改造方案
+
+## 一、现状分析：数据模型层级
+
+当前搜索子系统使用 5 层 Realm Object 构成一个嵌套的缓存/搜索/合并体系：
+
+```mermaid
+graph TD
+    subgraph "Realm 持久化层"
+        CLSO["CalibreLibrarySearchObject<br/>📦 单图书馆搜索条件"]
+        CLSVO["CalibreLibrarySearchValueObject<br/>📦 单数据源搜索结果"]
+        CUSO["CalibreUnifiedSearchObject<br/>📦 跨图书馆统一合并结果"]
+        CUO["CalibreUnifiedOffsets<br/>📦 每个图书馆的合并偏移量"]
+        CBR["CalibreBookRealm<br/>📦 图书元数据"]
+    end
+
+    CUSO -->|"unifiedOffsets: Map<libraryId, ?>"| CUO
+    CUSO -->|"books: List"| CBR
+    CUO -->|"searchObject"| CLSO
+    CLSO -->|"sources: Map<serverUrl, ?>"| CLSVO
+    CLSVO -->|"bookIds: List<Int32>"| CLSVO
+    CLSVO -->|"books: List"| CBR
+```
+
+### 关键模型定义
+
+| Realm Object | 文件位置 | 作用 | 关键属性 |
+|---|---|---|---|
+| [CalibreLibrarySearchObject](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Models/CalibreBrowser/CalibreSearchCache.swift#L33-L64) | CalibreSearchCache.swift:33 | 存储单图书馆的搜索条件 | `libraryId`, `search`, `sortBy`, `sortAsc`, `filters`, `sources` |
+| [CalibreLibrarySearchValueObject](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Models/CalibreBrowser/CalibreSearchCache.swift#L15-L31) | CalibreSearchCache.swift:15 | 单个数据源的搜索结果 | `generation`, `totalNumber`, `bookIds: List<Int32>`, `books: List<CalibreBookRealm>` |
+| [CalibreUnifiedSearchObject](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Models/CalibreBrowser/CalibreSearchCache.swift#L136-L174) | CalibreSearchCache.swift:136 | 跨图书馆统一搜索结果 | `search`, `sortBy`, `filters`, `libraryIds`, `unifiedOffsets`, `books`, `limitNumber`, `totalNumber` |
+| [CalibreUnifiedOffsets](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Models/CalibreBrowser/CalibreSearchCache.swift#L118-L134) | CalibreSearchCache.swift:118 | 每个图书馆在合并中的偏移状态 | `offset`, `beenCutOff`, `beenConsumed`, `searchObject`, `searchObjectSource` |
+| [CalibreUnifiedSearchRuntime](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Models/CalibreBrowser/CalibreSearchCache.swift#L181-L187) | CalibreSearchCache.swift:181 | 非持久化运行时状态 | `indexMap: [String:Int]`, `objectNotificationToken` |
+
+---
+
+## 二、生命周期完整追踪
+
+### 2.1 触发起点
+
+`CalibreUnifiedSearchObject` 有 **两个创建路径**：
+
+#### 路径 A：UI 驱动（LibraryInfoView）
+```
+用户操作（搜索/排序/筛选）
+  → LibraryInfoView.resetToFirstPage() [L168-180]
+  → librarySearchManager.retrieveUnifiedSearchObject() [L1587-1639]
+  → 若不存在则创建新对象，写入 Realm
+  → viewModel.setUnifiedSearchObject() [L120-158]
+```
+
+#### 路径 B：Shelf 驱动（ShelfDataManager）
+```
+书架添加书籍
+  → YabrShelfDataModel.addToShelf() [L137-223]
+  → searchManager.retrieveUnifiedSearchObject() [L175-183]
+  → 按作者创建 unified search，写入 Realm
+```
+
+### 2.2 七阶段响应式数据管线
+
+```mermaid
+sequenceDiagram
+    participant UI as UI Layer
+    participant RSO as retrieveUnifiedSearchObject
+    participant CSP as changesetPublisher
+    participant SRS as searchRefreshSubject
+    participant SRQ as searchRequestSubject
+    participant NET as CalibreServerService
+    participant MRQ as metadataRequestSubject
+    participant SMR as searchMergerRequestSubject
+
+    UI->>RSO: 1️⃣ 创建/查找 UnifiedSearchObject
+    RSO-->>UI: 返回 CalibreUnifiedSearchObject
+    CSP->>CSP: 2️⃣ Realm changesetPublisher 检测到新对象
+    CSP->>SMR: 发送合并请求
+    SMR->>SRS: 3️⃣ 对每个图书馆发送搜索刷新
+    SRS->>SRQ: 4️⃣ 构建搜索任务
+    SRQ->>NET: 5️⃣ 发起 HTTP/Realm 搜索
+    NET->>MRQ: 6️⃣ 获取图书元数据
+    MRQ->>SMR: 7️⃣ 元数据就绪，触发合并
+    SMR->>SMR: K-way merge 排序写入 UnifiedSearchObject.books
+```
+
+### 2.3 各阶段详解
+
+#### 阶段 1：创建 — [retrieveUnifiedSearchObject](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Models/CalibreBrowser/CalibreBrowser.swift#L1587-L1639)
+
+```swift
+// 三级查找：内存 dict → Realm query → 新建
+func retrieveUnifiedSearchObject(...) -> CalibreUnifiedSearchObject {
+    // 1. 先查 in-memory dict
+    if let objectId = cacheSearchUnifiedObjects[key] {
+        return unifiedSearches.where({ $0._id == objectId }).first!  // ⚠️ force unwrap
+    }
+    // 2. 再查 Realm (复杂的 filter 闭包匹配)
+    let existingObjs = unifiedSearches.where { ... }.filter({ object in ... })
+    if let cacheObj = existingObjs.first { return cacheObj }
+    // 3. 创建新对象（此时 realm == nil，由调用者写入 Realm）
+    let cacheObj = CalibreUnifiedSearchObject()
+    ...
+    return cacheObj
+}
+```
+
+> [!WARNING]
+> **问题**：该方法在 `CalibreLibrarySearchManager`（cacheRealmQueue）和 `YabrShelfDataModel`（dispatchQueue）和 UI（main thread）三个不同线程调用，但没有统一的线程安全保护。
+
+#### 阶段 2：注册监听 — [registerCacheUnifiedSearchObject](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Models/CalibreBrowser/CalibreBrowser.swift#L617-L701)
+
+在 `initCacheStore()` 中通过 `cacheRealm.objects(CalibreUnifiedSearchObject.self).changesetPublisher` 自动检测新插入的对象，然后：
+- 注册 `indexMap`（用于快速查找 book 位置）
+- 注册 `objectNotificationToken`（监听 `limitNumber` 变更）
+- 延迟 5 秒后决定是否需要触发合并
+
+> [!CAUTION]
+> **问题**：`asyncAfter(deadline: .now() + 5.0)` 硬编码延迟，无法适应不同网络速度。如果在 5 秒内数据未就绪，合并将在数据到达后由其他 changeset 触发，但时序不可预测。
+
+#### 阶段 3-4：搜索刷新 → 搜索请求 — [registerSearchRefreshReceiver](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Models/CalibreBrowser/CalibreBrowser.swift#L778-L818) + [registerSearchRequestReceiver](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Models/CalibreBrowser/CalibreBrowser.swift#L820-L914)
+
+搜索管线跨 **4 个 DispatchQueue** 执行：
+
+```
+searchRefreshSubject → cacheRealmQueue
+  → buildLibrarySearchTasks()
+  → searchRequestSubject → DispatchQueue.main (loading 计数)
+    → cacheWorkerQueue (网络请求)
+      → cacheRealmQueue (写结果)
+        → DispatchQueue.main (更新 loading 计数)
+```
+
+> [!WARNING]
+> **问题**：`DispatchQueue.main` 被用来管理 loading 计数（L822, L908），这是因为 `cacheSearchLibraryRuntime` 在 SwiftUI 视图中直接读取（如 [LibraryInfoBookListView:L566](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/LibraryInfoView/LibraryInfoBookListView.swift#L566)），将业务逻辑强绑定到了主线程。
+
+#### 阶段 5：网络搜索 — [searchLibraryBooks](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Models/CalibreBrowser/CalibreBrowser.swift#L2005-L2134)
+
+支持两种数据源：
+1. **HTTP**: `ajax/search/{libraryKey}` → Calibre Content Server API
+2. **Realm 离线**: 本地 `CalibreBookRealm` 查询
+
+> [!NOTE]
+> 离线搜索创建了独立的 `Realm(configuration:)` 实例 (L2111)，这意味着每次搜索都会创建新的 Realm 连接，不够高效。
+
+#### 阶段 6：元数据获取 — [registerMetadataRequestReceiver](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Models/CalibreBrowser/CalibreBrowser.swift#L916-L1018)
+
+获取 book metadata 后将 `CalibreBookRealm` 对象追加到 `sourceObj.books` 列表，这会触发 changeset 通知链，最终触发合并。
+
+> [!WARNING]
+> **问题**：`task.books.count > 20000` 检查（L922-923）只是打印空字符串，疑似未完成的调试代码。无批次大小限制保护。
+
+#### 阶段 7：K-way 合并 — [mergeBookListsNew](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Models/CalibreBrowser/CalibreBrowser.swift#L1658-L1757)
+
+核心合并算法是一个 **K-way merge sort**，使用 `MergeSortComparatorNew` 比较来自不同图书馆的已排序图书列表：
+
+```swift
+// 简化版逻辑：
+var heads = [...] // 每个图书馆的当前头部元素
+heads.sort(using: sortComparator) // 排序使 popLast() 取最优元素
+
+while mergedObj.books.count < mergedObj.limitNumber,
+      let headEntry = heads.popLast() {
+    mergedObj.books.append(head)       // 追加到合并结果
+    unifiedOffset.offset += 1          // 推进该图书馆偏移
+    // 如果该图书馆的本地数据耗尽但服务端还有更多
+    if offset >= sourceObj.books.count && totalNumber > books.count {
+        unifiedOffset.beenCutOff = true // 标记需要加载更多
+        break  // ← 整个合并停止！
+    }
+}
+```
+
+> [!CAUTION]
+> **严重问题**：
+> 1. 每次 `heads.append` + `heads.sort` 是 O(K·log K)，应该用堆（优先队列）O(log K)
+> 2. `fatalError("Shouldn't missing unifiedOffset")` (L1670) 在生产中会崩溃
+> 3. 合并在 `cacheRealm.write` 事务内执行，长时间锁定 Realm 写入
+> 4. 当任何一个图书馆被 `cutOff` 时，整个合并中止 → 用户看到不完整的结果
+
+---
+
+## 三、消费端分析
+
+### 3.1 消费者列表
+
+| 消费者 | 文件 | 绑定方式 | 用途 |
+|---|---|---|---|
+| [LibraryInfoBookListView](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/LibraryInfoView/LibraryInfoBookListView.swift#L19) | LibraryInfoBookListView.swift:19 | `@ObservedRealmObject` | 主图书列表展示 |
+| [LibraryInfoBookListInfoView](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/LibraryInfoView/LibraryInfoBookListInfoView.swift#L16) | LibraryInfoBookListInfoView.swift:16 | `@ObservedRealmObject` | 搜索结果信息弹窗 |
+| [LibraryInfoBookRow](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/LibraryInfoView/LibraryInfoBookRow.swift#L19) | LibraryInfoBookRow.swift:19 | `@ObservedRealmObject` | 列表行展示 |
+| [LibraryInfoView.ViewModel](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/LibraryInfoView/LibraryInfoViewModel.swift#L89) | LibraryInfoViewModel.swift:89 | `@Published property` | 状态管理 |
+| [SectionShelfController](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/ShelfView/SectionShelfController.swift#L46) | SectionShelfController.swift:46 | `dict property` | 分类书架展示 |
+| [YabrShelfDataModel.CategoryObject](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/ShelfView/ShelfDataManager.swift#L29) | ShelfDataManager.swift:29 | `optional property` | 发现书架 |
+
+### 3.2 消费模式问题
+
+1. **Realm 对象直接暴露到 View 层**：5 个 SwiftUI View 直接使用 `@ObservedRealmObject CalibreUnifiedSearchObject`，意味着：
+   - View 必须 `import RealmSwift`
+   - View 的测试需要真实 Realm 实例
+   - Realm schema 变更直接影响 UI 层
+
+2. **手动 `thaw()` 操作**：View 中直接执行 `unifiedSearchObject.realm?.thaw()` + `try! realm.write` ([LibraryInfoBookListView:L235-245](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/LibraryInfoView/LibraryInfoBookListView.swift#L235-L245))，违反单一职责原则
+
+3. **运行时状态混入 Realm Object**：`CalibreUnifiedSearchObject.loading` 和 `CalibreLibrarySearchObject.loading/error` 是非持久化属性，却定义在 Realm Object 中 (L160-161)
+
+---
+
+## 四、核心问题汇总
+
+| # | 问题 | 位置 | 严重度 | 类型 |
+|---|---|---|---|---|
+| 1 | 7 阶段管线全部在同一 2137 行文件中 | CalibreBrowser.swift | 🔴 | 可维护性 |
+| 2 | 跨 4 个 DispatchQueue 的线程安全靠人工保证 | L822, L831, L844, L908 | 🔴 | 线程安全 |
+| 3 | K-way merge 算法 O(K·logK) 应改为 O(logK) | L1730-1754 | 🟡 | 性能 |
+| 4 | 合并在 Realm write 事务内执行（长事务） | L1036-1094 | 🔴 | 性能/稳定性 |
+| 5 | `fatalError` 在生产代码中 | L1670 | 🔴 | 稳定性 |
+| 6 | `try!` 散布 20+ 处 | 全文件 | 🔴 | 稳定性 |
+| 7 | `retrieveUnifiedSearchObject` 多线程调用无锁 | L1587 + ShelfDataManager:L175 | 🟡 | 线程安全 |
+| 8 | Realm 对象直接暴露到 6 个 View | LibraryInfo* 系列 | 🟡 | 耦合 |
+| 9 | 5 秒硬编码延迟 | L660 | 🟢 | 可靠性 |
+| 10 | 运行时状态混入 Realm Object | L160-161, L62-63 | 🟢 | 设计 |
+| 11 | 一个 cutOff 阻断整个合并 | L1744 `break` | 🟡 | 功能 |
+
+---
+
+## 五、设计决策
+
+> [!NOTE]
+> 以下决策基于用户反馈确认（2026-06-06）。
+
+| # | 问题 | 决策 | 对架构的影响 |
+|---|---|---|---|
+| D1 | 合并结果是否持久化？ | **在线合并，仅缓存直接搜索结果** | 删除 `CalibreUnifiedSearchObject` Realm 持久化；合并结果仅存在于内存；`CalibreLibrarySearchObject` + `CalibreLibrarySearchValueObject` 保留 Realm 缓存 |
+| D2 | Shelf 是否复用搜索基础设施？ | **仍需跨 server/library 合并，但要轻量化** | Shelf 使用相同的合并 API，但引入轻量的 `ShelfSearchRequest` 限制结果数量，避免全量搜索 |
+| D3 | limitNumber 增量扩展？ | **保持现有方案，非优先** | 合并服务保留 `limit` 参数，内存合并时按 limit 截断 |
+| D4 | 离线搜索模式？ | **仅需搜索本地 library** | 移除 `file:///realm` hack；本地 library 直接查询主 Realm，不走网络搜索管线 |
+
+---
+
+## 六、现代化改造方案（基于设计决策更新）
+
+### 6.1 核心架构变更：合并结果从 Realm 移入内存
+
+```mermaid
+graph TD
+    subgraph "现有架构"
+        direction LR
+        A1["Realm 持久化"]
+        A2["CalibreUnifiedSearchObject ❌"]
+        A3["CalibreUnifiedOffsets ❌"]
+        A4["CalibreLibrarySearchObject ✅"]
+        A5["CalibreLibrarySearchValueObject ✅"]
+        A1 --> A2 & A3 & A4 & A5
+    end
+
+    subgraph "新架构"
+        direction LR
+        B1["Realm 缓存层（仅直接搜索结果）"]
+        B2["LibrarySearchCacheObject"]
+        B3["LibrarySearchResultObject"]
+        B1 --> B2 & B3
+
+        B4["内存合并层"]
+        B5["UnifiedSearchResult（value type）"]
+        B6["MergeState（per-library offset）"]
+        B4 --> B5 & B6
+    end
+
+    A4 -.->|"重命名"| B2
+    A5 -.->|"重命名"| B3
+    A2 -.->|"移入内存"| B5
+    A3 -.->|"移入内存"| B6
+```
+
+> [!TIP]
+> 这个变更直接解决了问题 #4（合并在 Realm write 事务内执行）和 #10（运行时状态混入 Realm Object），因为合并完全在内存中进行，不再需要 Realm 写事务。
+
+### 6.2 目标架构
+
+```mermaid
+graph TB
+    subgraph "View Layer（无 RealmSwift 导入）"
+        V1["LibraryInfoBookListView"]
+        V2["ShelfView"]
+    end
+
+    subgraph "ViewModel Layer"
+        VM1["BookListViewModel<br/>@MainActor ObservableObject"]
+        VM2["ShelfViewModel<br/>@MainActor ObservableObject"]
+    end
+
+    subgraph "Service Layer（Swift Concurrency）"
+        USS["UnifiedSearchService<br/>actor — 内存合并"]
+        LSS["LibrarySearchService<br/>actor — 搜索+元数据"]
+        LLS["LocalLibrarySearchService<br/>actor — 本地 library 专用"]
+    end
+
+    subgraph "Repository Layer"
+        SCR["SearchCacheRepository<br/>protocol"]
+    end
+
+    subgraph "Data Layer"
+        RC["RealmSearchCacheStore<br/>仅缓存 per-library 结果"]
+        NW["CalibreServerService"]
+    end
+
+    V1 --> VM1
+    V2 --> VM2
+    VM1 --> USS
+    VM2 --> USS
+    USS --> LSS
+    USS --> LLS
+    LSS --> SCR
+    LSS --> NW
+    LLS --> SCR
+    SCR -.-> RC
+```
+
+### 6.3 新增 Domain Models（Value Types）
+
+```swift
+// MARK: - 合并结果（纯内存，不持久化）
+
+struct UnifiedSearchResult: Sendable {
+    let id: UUID
+    let criteria: SearchCriteria
+    let libraryIds: Set<String>
+    var books: [BookSummary]
+    var totalNumber: Int
+    var limitNumber: Int
+    var isLoading: Bool
+    var libraryStatuses: [String: LibrarySearchStatus]
+}
+
+struct BookSummary: Identifiable, Sendable, Hashable {
+    let id: String          // CalibreBookRealm.primaryKey
+    let libraryId: String
+    let title: String
+    let authors: [String]
+    let coverURL: URL?
+    let formats: Set<String>
+    let rating: Int
+    let tags: [String]
+    let series: String
+    let seriesIndex: Double
+    let lastModified: Date
+    let timestamp: Date     // added date
+    let pubDate: Date
+    let inShelf: Bool
+}
+
+struct LibrarySearchStatus: Sendable {
+    let libraryId: String
+    var loadedCount: Int
+    var totalCount: Int
+    var isLoading: Bool
+    var isFullyLoaded: Bool
+    var error: SearchError?
+}
+
+enum SearchError: Error, Sendable {
+    case networkUnavailable
+    case serverError(String)
+    case realmError(String)
+}
+
+// MARK: - 合并偏移状态（纯内存，替代 CalibreUnifiedOffsets）
+
+struct MergeOffset: Sendable {
+    let libraryId: String
+    var offset: Int = 0
+    var isConsumed: Bool = false     // 该 library 所有结果已合并
+    var isCutOff: Bool = false       // 该 library 本地数据不足，需加载更多
+    var sourceKey: String = ""       // 当前使用的 server URL key
+}
+```
+
+### 6.4 Repository Protocol（仅管理 per-library 缓存）
+
+```swift
+/// 仅负责 per-library 搜索结果的 Realm 缓存
+protocol SearchCacheRepository: Sendable {
+    /// 获取某 library 的缓存搜索结果
+    func getLibrarySearchResult(
+        libraryId: String,
+        criteria: SearchCriteria,
+        sourceKey: String
+    ) async -> LibraryCachedResult?
+
+    /// 更新某 library 的缓存搜索结果（bookIds + metadata）
+    func updateLibrarySearchResult(
+        libraryId: String,
+        criteria: SearchCriteria,
+        sourceKey: String,
+        generation: Date,
+        totalNumber: Int,
+        bookIds: [Int32]
+    ) async throws
+
+    /// 获取已缓存的 BookSummary 列表（按 bookIds 顺序）
+    func getBookSummaries(
+        libraryId: String,
+        bookIds: [Int32],
+        range: Range<Int>
+    ) async -> [BookSummary]
+
+    /// 更新图书元数据
+    func updateBookMetadata(
+        serverUUID: String,
+        libraryName: String,
+        entries: [BookMetadataEntry]
+    ) async throws
+
+    /// 观察某 library 的搜索缓存变化
+    func observeLibrarySearch(
+        libraryId: String,
+        criteria: SearchCriteria
+    ) -> AsyncStream<LibraryCachedResult>
+}
+
+struct LibraryCachedResult: Sendable {
+    let libraryId: String
+    let generation: Date
+    let totalNumber: Int
+    let bookIds: [Int32]
+    let books: [BookSummary]     // 已获取 metadata 的部分
+    let sourceKey: String
+}
+```
+
+### 6.5 核心 Actor：UnifiedSearchService（内存合并）
+
+```swift
+actor UnifiedSearchService {
+    private let cacheRepository: SearchCacheRepository
+    private let librarySearchService: LibrarySearchService
+    private let localSearchService: LocalLibrarySearchService
+    private let libraryProvider: LibraryProvider
+
+    // 内存中的合并状态（替代 Realm 中的 CalibreUnifiedSearchObject）
+    private var activeSearches: [UUID: ActiveSearch] = [:]
+
+    struct ActiveSearch {
+        let criteria: SearchCriteria
+        let libraryIds: Set<String>
+        var mergeOffsets: [String: MergeOffset]     // 替代 CalibreUnifiedOffsets
+        var mergedBooks: [BookSummary]               // 替代 Realm List<CalibreBookRealm>
+        var totalNumber: Int
+        var limitNumber: Int
+        var isLoading: Bool
+        var continuation: AsyncStream<UnifiedSearchResult>.Continuation?
+    }
+
+    /// 主入口：搜索并返回实时更新流
+    func search(
+        criteria: SearchCriteria,
+        libraryIds: Set<String>
+    ) async throws -> AsyncStream<UnifiedSearchResult> {
+        let searchId = UUID()
+
+        return AsyncStream { continuation in
+            let search = ActiveSearch(
+                criteria: criteria,
+                libraryIds: libraryIds,
+                mergeOffsets: [:],
+                mergedBooks: [],
+                totalNumber: 0,
+                limitNumber: 100,
+                isLoading: true,
+                continuation: continuation
+            )
+            self.activeSearches[searchId] = search
+
+            // 并发搜索所有 library
+            Task {
+                await self.executeSearch(searchId: searchId)
+            }
+
+            continuation.onTermination = { _ in
+                Task { await self.cancelSearch(searchId) }
+            }
+        }
+    }
+
+    private func executeSearch(searchId: UUID) async {
+        guard let search = activeSearches[searchId] else { return }
+        let libraries = await libraryProvider.getActiveLibraries(ids: search.libraryIds)
+
+        // 对每个 library 并发搜索
+        await withTaskGroup(of: (String, LibraryCachedResult?).self) { group in
+            for library in libraries {
+                group.addTask {
+                    if library.isLocal {
+                        // D4: 本地 library 直接查 Realm
+                        let result = try? await self.localSearchService.search(
+                            library: library,
+                            criteria: search.criteria
+                        )
+                        return (library.id, result)
+                    } else {
+                        // 远程 library 走网络搜索
+                        let result = try? await self.librarySearchService.search(
+                            library: library,
+                            criteria: search.criteria
+                        )
+                        return (library.id, result)
+                    }
+                }
+            }
+
+            // 每个 library 结果到达时，立即增量合并
+            for await (libraryId, result) in group {
+                guard let result = result else { continue }
+                self.updateLibraryResult(searchId: searchId, libraryId: libraryId, result: result)
+                self.incrementalMerge(searchId: searchId)
+                self.emitUpdate(searchId: searchId)
+            }
+        }
+
+        // 所有 library 搜索完毕
+        activeSearches[searchId]?.isLoading = false
+        emitUpdate(searchId: searchId)
+    }
+
+    /// 内存中的 K-way merge（使用堆优化，替代 mergeBookListsNew）
+    private func incrementalMerge(searchId: UUID) {
+        guard var search = activeSearches[searchId] else { return }
+
+        let comparator = BookSummaryComparator(
+            sortBy: search.criteria.sortCriteria.by,
+            ascending: search.criteria.sortCriteria.ascending
+        )
+
+        // 构建优先队列
+        var heap = PriorityQueue<MergeHead>(comparator: comparator)
+        for (libraryId, offset) in search.mergeOffsets {
+            guard !offset.isConsumed,
+                  let cachedResult = libraryResults[libraryId],
+                  offset.offset < cachedResult.books.count
+            else { continue }
+
+            heap.push(MergeHead(
+                libraryId: libraryId,
+                books: cachedResult.books,
+                offset: offset.offset
+            ))
+        }
+
+        // O(N·logK) 合并
+        search.mergedBooks.removeAll(keepingCapacity: true)
+        search.totalNumber = search.mergeOffsets.values.reduce(0) { $0 + ($1.totalCount ?? 0) }
+
+        while search.mergedBooks.count < search.limitNumber {
+            guard let head = heap.pop() else { break }
+            search.mergedBooks.append(head.current)
+
+            search.mergeOffsets[head.libraryId]?.offset += 1
+
+            if let next = head.advance() {
+                heap.push(next)
+            } else {
+                // 该 library 本地数据耗尽
+                search.mergeOffsets[head.libraryId]?.isConsumed = true
+            }
+        }
+
+        activeSearches[searchId] = search
+    }
+
+    private func emitUpdate(searchId: UUID) {
+        guard let search = activeSearches[searchId] else { return }
+        search.continuation?.yield(UnifiedSearchResult(
+            id: searchId,
+            criteria: search.criteria,
+            libraryIds: search.libraryIds,
+            books: search.mergedBooks,
+            totalNumber: search.totalNumber,
+            limitNumber: search.limitNumber,
+            isLoading: search.isLoading,
+            libraryStatuses: search.mergeOffsets.mapValues { offset in
+                LibrarySearchStatus(
+                    libraryId: offset.libraryId,
+                    loadedCount: offset.offset,
+                    totalCount: offset.totalCount ?? 0,
+                    isLoading: offset.isLoading,
+                    isFullyLoaded: offset.isConsumed
+                )
+            }
+        ))
+    }
+}
+```
+
+### 6.6 本地 Library 搜索（决策 D4 — 简化离线模式）
+
+```swift
+/// 替代原来的 file:///realm hack，直接查询主 Realm
+actor LocalLibrarySearchService {
+    private let cacheRepository: SearchCacheRepository
+
+    func search(
+        library: CalibreLibrary,
+        criteria: SearchCriteria
+    ) async throws -> LibraryCachedResult {
+        // 直接查询主 Realm 中已同步的 CalibreBookRealm
+        // 不再创建独立的 Realm 连接（修复原有的效率问题）
+        return try await cacheRepository.queryLocalBooks(
+            serverUUID: library.server.uuid.uuidString,
+            libraryName: library.name,
+            criteria: criteria
+        )
+    }
+}
+```
+
+> [!TIP]
+> 相比原来在 `searchLibraryBooks()` (L2019-2131) 中每次创建新 Realm 实例并用 NSPredicate 查询，新方案复用 Repository 层的 Realm 连接，更高效且类型安全。
+
+### 6.7 轻量化 Shelf 合并（决策 D2）
+
+```swift
+/// Shelf 使用相同的 UnifiedSearchService，但通过 ShelfSearchRequest 限制范围
+extension UnifiedSearchService {
+    /// 为 Shelf "发现" 功能提供的轻量合并入口
+    func shelfSearch(
+        author: String,
+        limit: Int = 20  // Shelf 只需少量结果
+    ) async throws -> AsyncStream<UnifiedSearchResult> {
+        return try await search(
+            criteria: SearchCriteria(
+                searchString: "",
+                sortCriteria: .init(by: .Modified, ascending: false),
+                filterCriteriaCategory: ["Authors": Set([author])]
+            ),
+            libraryIds: []  // 搜索所有 library
+        )
+    }
+}
+
+/// ShelfViewModel 消费合并结果
+@MainActor
+final class ShelfViewModel: ObservableObject {
+    @Published var discoverSections: [ShelfSection] = []
+
+    private let searchService: UnifiedSearchService
+    private var categoryTasks: [String: Task<Void, Never>] = [:]
+
+    func addAuthorCategory(_ author: String) {
+        categoryTasks[author]?.cancel()
+        categoryTasks[author] = Task {
+            do {
+                let stream = try await searchService.shelfSearch(author: author, limit: 20)
+                for await result in stream {
+                    guard !Task.isCancelled else { break }
+                    self.updateSection(author: author, books: result.books)
+                }
+            } catch { }
+        }
+    }
+
+    private func updateSection(author: String, books: [BookSummary]) {
+        let section = ShelfSection(
+            id: "Author: \(author)",
+            name: author,
+            books: books.map { $0.toShelfModel() }
+        )
+        if let idx = discoverSections.firstIndex(where: { $0.id == section.id }) {
+            discoverSections[idx] = section
+        } else if !books.isEmpty {
+            discoverSections.append(section)
+        }
+    }
+}
+```
+
+> [!NOTE]
+> 与现有 `YabrShelfDataModel` 的关键区别：
+> - 不再为每个作者创建持久化的 `CalibreUnifiedSearchObject` Realm 对象
+> - 合并在内存中完成，`limit: 20` 保证轻量
+> - 使用 Swift Concurrency 的 `Task` 取消代替 Combine 的 `cancellables`
+
+### 6.8 ViewModel 层改造
+
+```swift
+@MainActor
+final class BookListViewModel: ObservableObject {
+    @Published private(set) var books: [BookSummary] = []
+    @Published private(set) var totalCount: Int = 0
+    @Published private(set) var isLoading: Bool = false
+    @Published private(set) var libraryStatuses: [LibrarySearchStatus] = []
+
+    @Published var searchString: String = ""
+    @Published var sortCriteria: LibrarySearchSort = .init()
+    @Published var filters: [String: Set<String>] = [:]
+    @Published var libraryIds: Set<String> = []
+
+    private let searchService: UnifiedSearchService
+    private var searchTask: Task<Void, Never>?
+
+    func performSearch() {
+        searchTask?.cancel()
+        isLoading = true
+
+        searchTask = Task {
+            do {
+                let stream = try await searchService.search(
+                    criteria: currentCriteria,
+                    libraryIds: libraryIds
+                )
+                for await result in stream {
+                    guard !Task.isCancelled else { break }
+                    self.books = result.books
+                    self.totalCount = result.totalNumber
+                    self.isLoading = result.isLoading
+                    self.libraryStatuses = Array(result.libraryStatuses.values)
+                }
+            } catch {
+                self.isLoading = false
+            }
+        }
+    }
+
+    func loadMore() {
+        Task {
+            try? await searchService.expandLimit(searchId: currentSearchId)
+        }
+    }
+
+    private var currentCriteria: SearchCriteria {
+        SearchCriteria(
+            searchString: searchString,
+            sortCriteria: sortCriteria,
+            filterCriteriaCategory: filters
+        )
+    }
+}
+```
+
+### 6.9 View 层改造
+
+```swift
+// ✅ 无 import RealmSwift
+struct LibraryInfoBookListView: View {
+    @StateObject var viewModel: BookListViewModel
+
+    var body: some View {
+        List {
+            ForEach(viewModel.books) { book in
+                BookRowView(book: book)
+            }
+            if viewModel.books.count < viewModel.totalCount {
+                ProgressView()
+                    .onAppear { viewModel.loadMore() }
+            }
+        }
+        .searchable(text: $viewModel.searchString)
+        .onSubmit(of: .search) { viewModel.performSearch() }
+        .overlay {
+            if viewModel.isLoading && viewModel.books.isEmpty {
+                ProgressView().scaleEffect(2)
+            }
+        }
+        .toolbar {
+            ToolbarItemGroup(placement: .navigationBarTrailing) {
+                sortMenuView()
+                    .disabled(viewModel.isLoading)
+            }
+        }
+    }
+}
+```
+
+---
+
+## 七、迁移路径
+
+### Phase 1：引入 Value Types + Repository 层（无功能变更）
+
+| 步骤 | 内容 | 文件 |
+|---|---|---|
+| 1.1 | 定义 `BookSummary` value type | [NEW] Models/BookSummary.swift |
+| 1.2 | 定义 `SearchCacheRepository` protocol | [NEW] Protocols/SearchCacheRepository.swift |
+| 1.3 | 实现 `RealmSearchCacheStore` 包装现有 Realm 逻辑 | [NEW] Repositories/RealmSearchCacheStore.swift |
+| 1.4 | 添加 `CalibreBookRealm → BookSummary` 转换 | [MODIFY] CalibreSearchCache.swift |
+
+### Phase 2：拆分 CalibreLibrarySearchManager → 3 个 Actor
+
+| 步骤 | 内容 | 从 CalibreBrowser.swift 提取 |
+|---|---|---|
+| 2.1 | 提取 `LibrarySearchService` actor（含元数据） | L778-1018 (搜索+元数据管线) |
+| 2.2 | 提取 `UnifiedSearchService` actor（内存合并） | L1020-1134 + L1658-1757 (合并逻辑) |
+| 2.3 | 创建 `LocalLibrarySearchService` actor | 从 L2019-2131 简化 |
+| 2.4 | 提取 `CategoryService` actor | L1137-1343 (分类) |
+| 2.5 | 提取 `BookSummaryComparator` + `PriorityQueue` | L1806-1908 → 新工具类 |
+
+### Phase 3：消除 Realm 合并持久化（决策 D1 落地）
+
+| 步骤 | 内容 |
+|---|---|
+| 3.1 | `UnifiedSearchService` 使用内存 `ActiveSearch` 替代 `CalibreUnifiedSearchObject` |
+| 3.2 | `MergeOffset` value type 替代 `CalibreUnifiedOffsets` Realm Object |
+| 3.3 | 删除 Realm schema 中的 `CalibreUnifiedSearchObject`、`CalibreUnifiedOffsets`（需 migration） |
+| 3.4 | 删除 `CalibreUnifiedSearchRuntime` |
+
+### Phase 4：ViewModel + View 层替换
+
+| 步骤 | 内容 |
+|---|---|
+| 4.1 | 创建 `BookListViewModel` 替代 `LibraryInfoView.ViewModel` |
+| 4.2 | 创建 `ShelfViewModel` 替代 `YabrShelfDataModel` |
+| 4.3 | View 层移除 `@ObservedRealmObject`，使用 `BookSummary` |
+| 4.4 | 移除 View 层的 `import RealmSwift`（6 个文件） |
+
+### Phase 5：稳定性修复
+
+| 步骤 | 内容 |
+|---|---|
+| 5.1 | 替换 `fatalError` → graceful error + logging |
+| 5.2 | 替换 `try!` → `do/catch` + `SearchError` |
+| 5.3 | 移除 `task.books.count > 20000` 调试代码 |
+| 5.4 | 部分合并：cutOff 不阻断，展示已有数据 |
+
+---
+
+## 八、Realm Schema 迁移策略
+
+```swift
+// 当前 schema version: 137
+// 新增 migration: version 138
+
+// 需要删除的 Object 类型：
+// - CalibreUnifiedSearchObject
+// - CalibreUnifiedOffsets
+// - CalibreUnifiedSearchRuntime（非持久化，无需迁移）
+
+// 保留的 Object 类型：
+// - CalibreLibrarySearchObject（重命名为 LibrarySearchCacheObject 可选）
+// - CalibreLibrarySearchValueObject（保留）
+// - CalibreBookRealm（保留）
+// - CalibreLibraryCategoryObject（保留）
+// - CalibreUnifiedCategoryObject（保留）
+
+migration.deleteData(forType: "CalibreUnifiedSearchObject")
+migration.deleteData(forType: "CalibreUnifiedOffsets")
+```
+
+> [!WARNING]
+> 此迁移为 **不可逆** 操作。需要确保新版本的 `UnifiedSearchService` 已完全就绪后再执行。建议在 Phase 3 完成后统一执行。
+
+---
+
+## 九、预期收益
+
+| 指标 | 现状 | 改造后 |
+|---|---|---|
+| CalibreBrowser.swift 行数 | 2137 | ~400（仅保留初始化和兼容桥接） |
+| Realm Object 数量（搜索相关） | 5 个 | 3 个（删除 2 个合并对象） |
+| View 层 Realm 依赖 | 6 个文件 `import RealmSwift` | 0 |
+| 合并算法复杂度 | O(N·K·logK) | O(N·logK) |
+| Realm write 事务长度 | ~200+ 行在单事务内 | 合并不涉及 Realm write |
+| `try!` / `fatalError` | 20+ 处 | 0 |
+| 线程安全模型 | 4 个手动 DispatchQueue | Swift actor 自动隔离 |

--- a/.agents/rules/workflow-rules.md
+++ b/.agents/rules/workflow-rules.md
@@ -3,7 +3,11 @@ trigger: always_on
 description: My custom workflow rules
 ---
 
-在开始任何任务之前，必须先读取 memory-bank 中的文档了解上下文；完成任务后，自动更新 memory-bank 文件
+在开始任何任务之前，必须先读取 .agents/memory-bank 中的文档了解上下文；完成任务后，自动更新 .agents/memory-bank 文件
 
-始终通过mcp修改项目文件
+每次先生成研究报告并制定实施计划，提请用户确认
+
+始终通过xcode mcp修改工程内容
+
+始终通过xcode build 和 test进行验证
 

--- a/.agents/rules/workflow-rules.md
+++ b/.agents/rules/workflow-rules.md
@@ -1,0 +1,9 @@
+---
+trigger: always_on
+description: My custom workflow rules
+---
+
+在开始任何任务之前，必须先读取 memory-bank 中的文档了解上下文；完成任务后，自动更新 memory-bank 文件
+
+始终通过mcp修改项目文件
+

--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ iOSInjectionProject/
 .DS_Store
 
 gha-creds-*.json
+
+.agents/skills
+.agents/skills_library

--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,4 @@ iOSInjectionProject/
 
 .DS_Store
 
-git_diff.txt
-.gemini/
 gha-creds-*.json

--- a/REFACTOR_PLAN.claude.md
+++ b/REFACTOR_PLAN.claude.md
@@ -1,0 +1,847 @@
+# REFACTOR_PLAN.md — YetAnotherEBookReader (D.S.Reader)
+
+> 基于对全部 88 个 Swift 源文件的完整分析，生成于 2026-06-05
+
+---
+
+## 一、项目现状速览
+
+### 核心目录结构（仅列有业务逻辑的路径）
+
+```
+YetAnotherEBookReader/
+├── YetAnotherEBookReaderApp.swift          # App 入口 (87行)
+├── MainView.swift                          # 主 TabView (419行)
+├── Models/
+│   ├── ModelData.swift                     # 🔴 核心状态管理 God Object (2180行)
+│   ├── CalibreBrowser/
+│   │   ├── CalibreBrowser.swift            # 🔴 搜索/浏览/缓存 God Class (2136行)
+│   │   ├── CalibreSearchCache.swift        # 搜索缓存 (187行)
+│   │   └── V2/
+│   │       ├── LibrarySearchServiceV2.swift # V2 搜索服务 (156行)
+│   │       ├── LibraryInfoViewModelV2.swift # V2 ViewModel (42行)
+│   │       └── LibraryInfoViewV2.swift      # V2 视图 (50行)
+│   ├── CalibreData.swift                   # 数据模型定义 (1542行)
+│   ├── RealmModel.swift                    # Realm 持久化模型 (1388行)
+│   ├── Book.swift                          # 图书模型 + 大量废弃代码 (378行)
+│   ├── BookAnnotation.swift                # 标注模型 (362行)
+│   ├── BookFiles.swift                     # 文件管理 (151行)
+│   ├── BookPreference.swift                # 阅读偏好 (120行)
+│   ├── ReadingSessionManager.swift         # 阅读会话 (187行)
+│   ├── FontsManager.swift                  # 字体管理 (113行)
+│   ├── DatabaseService.swift               # Realm 服务 (16行)
+│   ├── Constants.swift                     # 常量 (25行)
+│   └── ...其他小文件
+├── Network/
+│   ├── CalibreServerService.swift          # 🔴 API 服务 God Class (1388行)
+│   ├── BookDownloadManager.swift           # 下载管理 (316行)
+│   ├── DSReaderHelperConnector.swift        # Helper 插件连接 (222行)
+│   ├── Downloader.swift                    # 简易下载器 (89行)
+│   ├── ImageRequest.swift                  # Kingfisher 适配 (84行)
+│   └── CalibreActivityLogger.swift         # 活动日志 (113行)
+├── Views/
+│   ├── Reader/
+│   │   ├── YabrEBookReader.swift           # 阅读器路由入口 (204行)
+│   │   ├── YabrEBookReaderMetaSource.swift # 元数据源 (294行)
+│   │   ├── YabrReaderSettingsView.swift    # 阅读设置 (458行)
+│   │   └── ...
+│   ├── FolioReaderView/
+│   │   ├── Providers.swift                 # 🔴 FolioReader 数据提供者 (857行, 含370行废弃代码)
+│   │   ├── EpubFolioReaderContainer.swift  # FolioReader 容器 (187行)
+│   │   ├── Configuration.swift             # FolioReader 配置 (65行)
+│   │   └── MyFolioReaderCenterDelegate.swift # 委托 (57行)
+│   ├── ReadiumView/
+│   │   ├── YabrReadiumReaderViewController.swift  # Readium 控制器 (747行)
+│   │   ├── YabrReadiumEPUBViewController.swift    # EPUB 特化 (162行)
+│   │   └── YabrReadiumPDFViewController.swift     # PDF 特化 (51行)
+│   ├── PDFView/
+│   │   ├── YabrPDFViewController.swift     # 🔴 PDF 阅读器 God VC (1716行)
+│   │   ├── YabrPDFView.swift               # PDF SwiftUI 包装 (548行)
+│   │   └── ListViews/ (13个文件)            # PDF 侧边栏 UIKit 视图
+│   ├── BookDetailView/
+│   │   ├── BookDetailView.swift            # 图书详情 (802行)
+│   │   └── ...6个辅助文件
+│   ├── LibraryInfoView/
+│   │   ├── LibraryInfoBookListView.swift   # 图书列表 (714行)
+│   │   └── ...7个辅助文件
+│   ├── ShelfView/
+│   │   ├── SectionShelfController.swift    # UIKit 书架 (612行)
+│   │   ├── RecentShelfController.swift     # UIKit 最近 (479行)
+│   │   ├── ShelfDataManager.swift          # 🔴 错放在 Views 的数据管理 (392行)
+│   │   └── ...UI 包装文件
+│   ├── SettingsView/
+│   │   ├── SettingsView.swift              # 设置主页 (350行)
+│   │   ├── ServerView/
+│   │   │   ├── AddModServerView.swift      # 服务器配置 (542行)
+│   │   │   └── ServerOptionsDSReaderHelper.swift # Helper 配置 (417行)
+│   │   └── ...其他设置文件
+│   ├── DictView/ (7个文件)                  # 词典功能
+│   └── ...其他视图
+├── ViewController/
+│   ├── FolioReaderViewController.swift     # UIKit 遗留 (89行)
+│   ├── MyReaderViewController.swift        # UIKit 遗留 (22行)
+│   └── ...
+└── Libs/ (3个本地库)                        # HAControls, SMSegmentView, ZFDragableModalTransition
+```
+
+### 技术债总量估算
+
+| 指标 | 数值 |
+|------|------|
+| **总 Swift 代码行数** | **28,702 行** |
+| **Swift 源文件数** | **88 个** |
+| **超过 300 行的文件** | **15 个** (占总行数 60%+) |
+| **超过 1000 行的文件** | **5 个** (占总行数 32%) |
+| **已标记废弃的代码项** | **11 处** (~600 行) |
+| **导入 RealmSwift 的文件** | **36 个** (含视图层 20+ 个) |
+| **导入 FolioReaderKit 的文件** | **7 个** |
+| **导入 Readium 模块的文件** | **10 个** |
+| **DispatchQueue 使用点** | **50+ 处** |
+| **@Published 属性总数** | **60+ 个** (仅 ModelData 就有 18 个) |
+| **测试覆盖率** | **~0%** (仅 1 个占位测试) |
+
+**问题类型分布**：
+
+| 问题类型 | 数量 | 占比 |
+|---------|------|------|
+| God Object / 超大文件 | 5 | 18% |
+| 层级违反 (Realm 泄漏到视图层) | 20+ | 36% |
+| 重复代码 (三引擎三套实现) | 3 组 | 11% |
+| 废弃代码未清理 | 11 处 | 14% |
+| 线程安全问题 | 5 处 | 7% |
+| 数据流混乱 | 3 处 | 7% |
+| 缺失测试 | 全局 | 7% |
+
+---
+
+## 二、架构问题清单
+
+### [A01] ModelData God Object — 2180 行的上帝类
+
+- **位置**：[ModelData.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Models/ModelData.swift) (L1-2180)
+- **现象**：单个 `ObservableObject` 承担了服务器管理、图书馆管理、图书管理、下载管理、阅读位置管理、Web 服务器管理、数据库初始化、书架管理、字体管理、会话管理等全部职责。包含 18 个 `@Published` 属性、6 个 Combine Subject、多个静态 DispatchQueue。
+- **影响**：任何一个 `@Published` 属性变化会触发所有观察此对象的 SwiftUI 视图重新计算。新功能开发必须修改此文件，极高的合并冲突风险。无法单独测试任何功能模块。
+- **严重程度**：🔴 高
+
+---
+
+### [A02] CalibreBrowser.swift (CalibreLibrarySearchManager) — 2137 行的搜索/浏览/缓存巨类
+
+- **位置**：[CalibreBrowser.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Models/CalibreBrowser/CalibreBrowser.swift) (L1-2137)
+- **现象**：文件中包含 `CalibreLibrarySearchManager` 类 (L161-2137) 及多个辅助 struct/enum (L13-160)。该类集搜索、缓存管理、分类浏览、统一搜索合并于一身。持有 `private let modelData: ModelData` (L169) 直接引用和两个私有 DispatchQueue (L182-183) 进行 Realm 缓存操作。使用 `force unwrap` 的 `cacheRealm: Realm!` (L180)。
+- **影响**：单文件承担过多职责，2137 行难以维护。Realm 缓存操作分散在多个 DispatchQueue 间，线程安全依赖人工保证。`try! cacheRealm.write` 散布在整个类中（如 L265, L273, L281, L396, L410, L432 等），任何 Realm 异常都会 crash。
+- **严重程度**：🔴 高
+
+---
+
+### [A03] YabrPDFViewController — 1716 行的超大 ViewController
+
+- **位置**：[YabrPDFViewController.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/PDFView/YabrPDFViewController.swift) (L1-1716)
+- **现象**：一个 UIViewController 包含了 PDF 渲染、标注绘制(L502-650)、书签管理(L802-900)、搜索(L1052-1200)、分享导出(L1202-1350)、阅读位置追踪(L1352-1500)、主题管理(L1502-1650)、导航栏(L202-350)、手势处理(L652-800) 等全部功能。拥有约 40 个属性。
+- **影响**：无法单独测试任何子功能。添加新 PDF 功能需要在 1700+ 行中找到正确位置。包含多处 `DispatchQueue.global`→`DispatchQueue.main` 的线程跳转 (L598, L625, L813, L829)。
+- **严重程度**：🔴 高
+
+---
+
+### [A04] CalibreServerService — 1388 行的网络 God Service
+
+- **位置**：[CalibreServerService.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Network/CalibreServerService.swift) (L1-1388)
+- **现象**：所有 Calibre API 调用集中在单个类中（~15 个 API 端点方法）。通过 `weak var modelData: ModelData?` (L12-15) 直接引用 ModelData。错误处理不统一：混合使用 `Result<T,Error>`、可选 completion handler、Combine publisher。全部使用 URLSession completion handler（无 async/await）。
+- **影响**：无法单独测试网络请求。错误处理不一致导致 UI 层无法统一展示错误。主线程回调分散在各方法中 (L346, L569)。
+- **严重程度**：🔴 高
+
+---
+
+### [A05] RealmSwift 泄漏到视图层 — 36 个文件导入 RealmSwift
+
+- **位置**：全局，以下视图文件不应导入 RealmSwift：
+  - [MainView.swift:L11](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/MainView.swift#L11)
+  - [BookDetailView.swift:L11](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/BookDetailView/BookDetailView.swift#L11)
+  - [LibraryInfoBookListView.swift:L9](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/LibraryInfoView/LibraryInfoBookListView.swift#L9)
+  - [SectionShelfController.swift:L12](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/ShelfView/SectionShelfController.swift#L12)
+  - [ShelfDataManager.swift:L11](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/ShelfView/ShelfDataManager.swift#L11)
+  - [Providers.swift:L10](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/FolioReaderView/Providers.swift#L10)
+  - [BookDownloadManager.swift:L11](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Network/BookDownloadManager.swift#L11)
+  - ...及另外 13+ 个视图文件
+- **现象**：视图层直接使用 Realm `Results`、`Object` 类型，进行 Realm 查询和写入。
+- **影响**：无法替换持久化方案（如迁移到 SwiftData）。视图直接依赖数据库，违反分层架构。Realm 的线程限制（对象不能跨线程）在视图层更容易被违反。
+- **严重程度**：🔴 高
+
+---
+
+### [A06] 阅读位置保存/恢复 — 三引擎三套实现
+
+- **位置**：
+  - FolioReader 路径：[Providers.swift:L702-857](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/FolioReaderView/Providers.swift#L702-L857) + [MyFolioReaderCenterDelegate.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/FolioReaderView/MyFolioReaderCenterDelegate.swift)
+  - Readium 路径：[YabrReadiumReaderViewController.swift:L352-430](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/ReadiumView/YabrReadiumReaderViewController.swift#L352-L430)
+  - PDF 路径：[YabrPDFViewController.swift:L1352-1500](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/PDFView/YabrPDFViewController.swift#L1352-L1500)
+- **现象**：每个阅读引擎有独立的位置保存/恢复逻辑，各自转换为 `BookDeviceReadingPosition` 并写入 Realm，但转换代码各不相同。
+- **影响**：修复位置同步 bug 需要在三处同步修改。新增阅读引擎需要重新实现整套逻辑。不同引擎间的位置数据格式可能不一致。
+- **严重程度**：🔴 高
+
+---
+
+### [A07] Providers.swift 中 ~370 行废弃代码仍然存在
+
+- **位置**：[Providers.swift:L330-700](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/FolioReaderView/Providers.swift#L330-L700)
+- **现象**：
+  - L330: `@available(*, deprecated, message: "replaced by BookHighlightRealm")` — 旧的高亮处理类，约 170 行
+  - L501: `@available(*, deprecated, message: "replaced by BookDeviceReadingPositionRealm")` — 旧的位置处理类，约 200 行
+- **影响**：增加维护负担和代码阅读成本。编译时间浪费。
+- **严重程度**：🟡 中
+
+---
+
+### [A08] 视图层直接访问 ModelData — 无 ViewModel 分隔
+
+- **位置**：几乎所有视图文件，典型例子：
+  - [BookDetailView.swift:L22-80](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/BookDetailView/BookDetailView.swift#L22-L80) — 直接读写 modelData 属性
+  - [LibraryInfoBookListView.swift:L352-550](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/LibraryInfoView/LibraryInfoBookListView.swift#L352-L550) — 搜索防抖、分页逻辑内联在视图中
+  - [MainView.swift:L82-250](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/MainView.swift#L82-L250) — 直接读写 modelData.activeTab
+- **现象**：视图通过 `@EnvironmentObject var modelData: ModelData` 直接访问 2180 行的 God Object，绕过任何 ViewModel 层。搜索防抖、分页、过滤等逻辑内联在 View body 中。
+- **影响**：ModelData 任何属性变化触发全体视图重绘。视图逻辑不可测试。无法区分读/写访问权限。
+- **严重程度**：🔴 高
+
+---
+
+### [A09] DSReaderHelperConnector 中的 DispatchQueue.main.sync — 脆弱的线程安全
+
+- **位置**：[DSReaderHelperConnector.swift:L29-35](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Network/DSReaderHelperConnector.swift#L29-L35)
+- **现象**：`urlSession` 计算属性中使用 `Thread.isMainThread` 检查后决定是否 `DispatchQueue.main.sync`：
+  ```swift
+  if Thread.isMainThread == false {
+      DispatchQueue.main.sync {
+          URLCredentialStorage.shared.set(userCredential, for: space)
+      }
+  } else {
+      URLCredentialStorage.shared.set(userCredential, for: space)
+  }
+  ```
+  虽有主线程检查避免直接死锁，但 `DispatchQueue.main.sync` 在非主线程调用时仍会阻塞当前线程等待主线程完成，如果主线程此时等待当前线程持有的锁，仍可能间接死锁。
+- **影响**：潜在的间接死锁风险。此外，每次访问 `urlSession` 属性都重新设置 credential，效率低下。
+- **严重程度**：🟡 中
+
+---
+
+### [A10] ShelfDataManager 错放在 Views 目录
+
+- **位置**：[ShelfDataManager.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/ShelfView/ShelfDataManager.swift) (392行)
+- **现象**：数据管理类放在 `Views/ShelfView/` 目录下，包含大量 Realm 操作和 Combine 管道。
+- **影响**：违反目录组织约定。其他需要书架数据的模块找不到这个类。暗示整个项目的分层边界不清晰。
+- **严重程度**：🟡 中
+
+---
+
+### [A11] CalibreData.swift — 1542 行的数据模型巨文件
+
+- **位置**：[CalibreData.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Models/CalibreData.swift) (L1-1542)
+- **现象**：16+ 个 struct/enum 定义集中在单个文件中，包括 `CalibreServer`、`CalibreLibrary`、`CalibreBook`、`Format`、`ReaderType`、`BookDeviceReadingPosition` 等。`CalibreBook` 在 L1352-1542 有大量计算属性，部分属于视图层关注点。
+- **影响**：文件过长难以导航。不同领域的模型混在一起增加理解成本。
+- **严重程度**：🟡 中
+
+---
+
+### [A12] RealmModel.swift — 1388 行的 Realm 模型巨文件
+
+- **位置**：[RealmModel.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Models/RealmModel.swift) (L1-1388)
+- **现象**：12+ 个 Realm Object 子类全部定义在单个文件中。包含废弃的 `CalibreBookLastReadPositionRealm` (L582, `@available(*, deprecated)`)。复杂的线性迁移逻辑 (L1002-1300)。导入了 `ReadiumShared` 和 `ReadiumNavigator` — 持久化层依赖阅读框架。
+- **影响**：Realm 模型与 Readium 类型耦合，意味着升级 Readium 可能需要 Realm 迁移。迁移逻辑难以测试。
+- **严重程度**：🟡 中
+
+---
+
+### [A13] Book.swift 中约 200 行废弃代码
+
+- **位置**：[Book.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Models/Book.swift)
+  - [L13](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Models/Book.swift#L13): `@available(*, deprecated)` `InShelfBook`
+  - [L20](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Models/Book.swift#L20): `@available(*, deprecated)` `CalibreBookMetadata`
+  - [L223](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Models/Book.swift#L223): `@available(*, deprecated)` `CalibreBookEntry`
+  - [L257](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Models/Book.swift#L257): `@available(*, deprecated)` `CalibreBookEntryCodable`
+- **现象**：378 行中约 200+ 行是标记为废弃的旧数据迁移结构体。
+- **影响**：增加编译时间和代码复杂度。新开发者易混淆新旧 API。
+- **严重程度**：🟡 中
+
+---
+
+### [A14] 高亮/标注处理 — 三引擎重复实现
+
+- **位置**：
+  - FolioReader：[Providers.swift:L702-750](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/FolioReaderView/Providers.swift#L702-L750)
+  - Readium：[YabrReadiumReaderViewController.swift:L432-500](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/ReadiumView/YabrReadiumReaderViewController.swift#L432-L500)
+  - PDF：[YabrPDFViewController.swift:L502-650](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/PDFView/YabrPDFViewController.swift#L502-L650)
+- **现象**：三个阅读引擎各自实现高亮的持久化和恢复逻辑。
+- **影响**：同 [A06]，修 bug 需三处同步。
+- **严重程度**：🟡 中
+
+---
+
+### [A15] 主题/外观设置 — 三引擎重复实现
+
+- **位置**：
+  - FolioReader：[Configuration.swift:L10-65](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/FolioReaderView/Configuration.swift#L10-L65)
+  - Readium：[YabrReadiumReaderViewController.swift:L582-650](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/ReadiumView/YabrReadiumReaderViewController.swift#L582-L650)
+  - PDF：[YabrPDFViewController.swift:L1502-1650](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/PDFView/YabrPDFViewController.swift#L1502-L1650)
+- **现象**：用户偏好（字体、主题、颜色）到各引擎的转换逻辑各自实现。
+- **影响**：新增一个阅读偏好选项需要在三个地方实现。
+- **严重程度**：🟡 中
+
+---
+
+### [A16] BookDetailView — 802 行的超大 SwiftUI 视图
+
+- **位置**：[BookDetailView.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/BookDetailView/BookDetailView.swift) (L1-802)
+- **现象**：body 约 120 行，15+ 个 @State 属性，多个 `.sheet` 修饰符链式调用 (L722-793)。直接导入 RealmSwift (L11)。
+- **影响**：SwiftUI 预览加载缓慢。修改任何部分需要理解整个 802 行上下文。
+- **严重程度**：🟡 中
+
+---
+
+### [A17] LibraryInfoBookListView — 714 行，业务逻辑内联
+
+- **位置**：[LibraryInfoBookListView.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/LibraryInfoView/LibraryInfoBookListView.swift) (L1-714)
+- **现象**：搜索防抖逻辑 (L352-450)、分页加载 (L552-650)、过滤工具栏 (L452-550) 全部内联在视图中。
+- **影响**：搜索和分页逻辑不可单独测试。视图职责过重。
+- **严重程度**：🟡 中
+
+---
+
+### [A18] V1/V2 共存 — 未完成的架构迁移
+
+- **位置**：
+  - V1：[CalibreBrowser.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Models/CalibreBrowser/CalibreBrowser.swift) (2136行)
+  - V2：[LibrarySearchServiceV2.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Models/CalibreBrowser/V2/LibrarySearchServiceV2.swift) (156行)
+- **现象**：V2 仅迁移了搜索功能 (156行 vs V1 2136行)，V1 仍处理绝大部分功能。两套系统可能同时运行。
+- **影响**：维护两套系统的成本。新功能不确定应添加到 V1 还是 V2。
+- **严重程度**：🟡 中
+
+---
+
+### [A19] 网络层无统一错误处理
+
+- **位置**：[CalibreServerService.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Network/CalibreServerService.swift) 全文
+- **现象**：混用 `Result<T, Error>`、可选 completion handler、Combine publisher、静默失败 (guard-else 直接 return)。没有自定义 Error 类型。
+- **影响**：UI 层无法统一展示错误信息。网络错误被静默吞掉，用户看不到反馈。调试困难。
+- **严重程度**：🟡 中
+
+---
+
+### [A20] CalibreLibrarySearchManager 强引用 ModelData + Realm force unwrap
+
+- **位置**：[CalibreBrowser.swift:L169, L180-181](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Models/CalibreBrowser/CalibreBrowser.swift#L169)
+- **现象**：`private let modelData: ModelData` 强引用 ModelData，可能造成循环引用（ModelData 通过 `lazy var librarySearchManager` 持有它）。`private var cacheRealm: Realm!` 和 `var cacheRealmConf: Realm.Configuration!` 使用隐式解包可选值。整个类中大量使用 `try! cacheRealm.write` (20+ 处)，任何一次 Realm 写入异常即会 crash。
+- **影响**：潜在循环引用导致内存泄漏。force unwrap 和 `try!` 在边缘场景（磁盘满、迁移失败等）会导致崩溃。
+- **严重程度**：🟡 中
+
+---
+
+### [A21] UIKit/SwiftUI 混合书架 — 复杂桥接
+
+- **位置**：
+  - [SectionShelfController.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/ShelfView/SectionShelfController.swift) (612行) — UICollectionViewController
+  - [RecentShelfController.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/ShelfView/RecentShelfController.swift) (479行) — UICollectionViewController
+  - [SectionShelfUI.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/ShelfView/SectionShelfUI.swift) / [RecentShelfUI.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/ShelfView/RecentShelfUI.swift) — UIViewControllerRepresentable 包装
+- **现象**：UIKit UICollectionViewController 通过 Representable 包装嵌入 SwiftUI，且控制器内部使用 Combine 订阅 ModelData。
+- **影响**：双向数据流复杂。UIKit 和 SwiftUI 生命周期交叉导致难以调试的问题。
+- **严重程度**：🟡 中
+
+---
+
+### [A22] CalibreSearchCache 中 4 个废弃属性仍在使用
+
+- **位置**：[CalibreSearchCache.swift:L49-59](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Models/CalibreBrowser/CalibreSearchCache.swift#L49-L59)
+- **现象**：4 个属性标记为 `@available(*, deprecated, message: "use sources")`，但仍被 CalibreBrowser.swift 引用。
+- **影响**：废弃迁移未完成，增加代码理解难度。
+- **严重程度**：🟢 低
+
+---
+
+### [A23] DatabaseService — 使用 Force Unwrap 的 Realm 实例
+
+- **位置**：[DatabaseService.swift:L12-13](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Models/DatabaseService.swift#L12-L13)
+- **现象**：`@Published var realmConf: Realm.Configuration!` 和 `@Published var realm: Realm!` 使用隐式解包可选值。
+- **影响**：在数据库初始化失败时会 crash，而非优雅降级。
+- **严重程度**：🟡 中
+
+---
+
+### [A24] Readium 类型泄漏到 RealmModel 持久化层
+
+- **位置**：[RealmModel.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Models/RealmModel.swift) — 顶部导入 `ReadiumShared`, `ReadiumNavigator`
+- **现象**：Realm 模型文件依赖 Readium SDK 类型（如 `Locator`）进行阅读位置序列化。
+- **影响**：升级 Readium SDK 时可能需要 Realm 数据迁移。持久化层与阅读引擎耦合，无法独立演进。
+- **严重程度**：🟡 中
+
+---
+
+### [A25] 测试覆盖几乎为零
+
+- **位置**：[LibrarySearchServiceV2Tests.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/../YetAnotherEBookReaderTests/LibrarySearchServiceV2Tests.swift) (仅 11 行，占位测试)
+- **现象**：整个项目仅有一个占位测试文件，无实际断言。无 UI 测试，无集成测试，无测试基础设施。
+- **影响**：重构无安全网。无法验证回归。无法自动化验收。
+- **严重程度**：🔴 高
+
+---
+
+### [A26] Readium ViewController 中的 timing hack
+
+- **位置**：
+  - [YabrReadiumReaderViewController.swift:L629](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/ReadiumView/YabrReadiumReaderViewController.swift#L629): `DispatchQueue.main.asyncAfter(deadline: .now() + 0.1)`
+  - [YabrReadiumReaderViewController.swift:L681](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/ReadiumView/YabrReadiumReaderViewController.swift#L681): `DispatchQueue.main.asyncAfter(deadline: .now() + 0.1)`
+- **现象**：通过固定延迟的 asyncAfter 来解决竞态条件，而非使用正确的同步机制。
+- **影响**：在不同性能的设备上行为不一致。可能导致间歇性 bug。
+- **严重程度**：🟢 低
+
+---
+
+### [A27] Realm ↔ 值类型手动转换 — 大量样板代码
+
+- **位置**：散布在 [RealmModel.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Models/RealmModel.swift)、[CalibreBrowser.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Models/CalibreBrowser/CalibreBrowser.swift)、[ModelData.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Models/ModelData.swift) 中
+- **现象**：每个 Realm Object 都有对应的 struct 在 CalibreData.swift 中，转换需要约 50 行手写映射代码。转换逻辑分散在多个文件中。
+- **影响**：新增字段需要在 3-4 个地方同步修改。转换代码容易遗漏字段。
+- **严重程度**：🟡 中
+
+---
+
+## 三、重构优先级矩阵
+
+| 优先级 | 问题编号 | 任务描述 | 影响范围 | 难度 | 预计改动文件数 |
+|--------|---------|---------|---------|------|-------------|
+| **P0** | A01 | 拆分 ModelData God Object | 全局 (88文件中36个直接引用) | 高 | 40+ |
+| **P0** | A25 | 建立测试基础设施 | 全局 | 中 | 10+ |
+| **P0** | A05 | 引入 Repository 层隔离 Realm | 全局 (36个文件) | 高 | 36 |
+| **P1** | A06+A14+A15 | 统一阅读引擎抽象层 | Reader (19文件) | 高 | 19 |
+| **P1** | A03 | 拆分 YabrPDFViewController | PDFView (14文件) | 中 | 8 |
+| **P1** | A04 | 重构 CalibreServerService | Network (6文件) | 中 | 6 |
+| **P1** | A02 | 拆分/重构 CalibreBrowser + 完成 V2 迁移 | Models (5文件) | 高 | 8 |
+| **P1** | A08 | 为主要视图引入 ViewModel | Views (15文件) | 中 | 15 |
+| **P1** | A09 | 重构 DSReaderHelper 线程安全 | Network (1文件) | 低 | 1 |
+| **P2** | A07+A13+A22 | 清理废弃代码 | 散布 | 低 | 5 |
+| **P2** | A11 | 拆分 CalibreData.swift | Models (1文件→多文件) | 低 | 5 |
+| **P2** | A12+A24 | 拆分 RealmModel + 解耦 Readium | Models | 中 | 4 |
+| **P2** | A10 | 移动 ShelfDataManager 到 Models | Views→Models | 低 | 2 |
+| **P2** | A16+A17 | 拆分 BookDetailView + LibraryInfoBookListView | Views | 低 | 4 |
+| **P2** | A21 | 书架视图 SwiftUI 原生化 | ShelfView (5文件) | 高 | 7 |
+| **P2** | A19 | 统一网络错误处理 | Network | 中 | 6 |
+
+> **P0 定义**：不改会阻塞后续所有重构  
+> **P1 定义**：高价值，可独立完成，不依赖其他任务  
+> **P2 定义**：有益但可延后
+
+---
+
+## 四、P0 任务详细说明
+
+### P0-1：拆分 ModelData God Object
+
+- **涉及文件**：
+  - [ModelData.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Models/ModelData.swift) (主要修改)
+  - 36+ 个引用 `modelData` 的视图文件 (更新引用)
+  - 新建 5-7 个服务文件
+
+- **当前状态**：
+  ```swift
+  // ModelData.swift — 2180 行，18 个 @Published 属性
+  class ModelData: ObservableObject {
+      @Published var calibreServers = [String: CalibreServer]()
+      @Published var calibreLibraries = [String: CalibreLibrary]()
+      @Published var booksInShelf = [String: CalibreBook]()
+      @Published var selectedBookId: String? = nil
+      @Published var downloadManager = BookDownloadManager()
+      @Published var sessionManager = ReadingSessionManager()
+      @Published var updatingMetadata = false
+      @Published var fontsManager = FontsManager()
+      // ... 10+ 更多 @Published
+      // ... 2000+ 行方法
+      
+      func addServer(...) { ... }
+      func syncLibrary(...) { ... }
+      func saveBooksMetadata(...) { ... }
+      func updateReadingPosition(...) { ... }
+      func setupWebServer() { ... }
+      // ... 50+ 方法
+  }
+  ```
+
+- **目标状态**：
+  ```swift
+  // ModelData.swift — ~200 行，协调各服务
+  class ModelData: ObservableObject {
+      let serverService: CalibreServerManager  // 服务器管理
+      let libraryService: CalibreLibraryManager // 图书馆管理
+      let bookService: CalibreBookManager       // 图书管理
+      let shelfService: ShelfService            // 书架管理
+      let downloadService: DownloadService      // 下载管理
+      let webServerService: WebServerService    // 本地服务器
+      let databaseService: DatabaseService      // 数据库初始化
+      
+      @Published var activeTab = 0
+      @Published var selectedBookId: String?
+  }
+  
+  // CalibreServerManager.swift — ~300 行
+  class CalibreServerManager: ObservableObject {
+      @Published var servers = [String: CalibreServer]()
+      func addServer(...) { ... }
+      func removeServer(...) { ... }
+  }
+  
+  // CalibreBookManager.swift — ~400 行
+  class CalibreBookManager: ObservableObject {
+      @Published var booksInShelf = [String: CalibreBook]()
+      func saveBooksMetadata(...) { ... }
+      func getBook(...) { ... }
+  }
+  // ... 其他服务类类似
+  ```
+
+- **执行步骤**：
+  1. 在 `Models/` 下创建 `Services/` 子目录
+  2. 提取 `CalibreServerManager`：从 ModelData 移出 L350-700 (服务器管理方法) 和 `calibreServers`、`calibreServerInfoStaging` 属性
+  3. 提取 `CalibreLibraryManager`：移出 L700-1000 (图书馆管理) 和 `calibreLibraries`、`calibreLibraryInfoStaging`、`librarySyncStatus` 属性
+  4. 提取 `CalibreBookManager`：移出 L1000-1500 (图书管理) 和 `booksInShelf`、`booksAnnotation` 属性
+  5. 提取 `ReadingPositionService`：移出 L1500-1700
+  6. 提取 `WebServerService`：移出 L1850-2000 (GCDWebServer 相关)
+  7. 在 ModelData 中保留服务实例引用和跨服务协调逻辑
+  8. 更新所有视图文件，将 `modelData.addServer(...)` 改为 `modelData.serverService.addServer(...)` 或注入具体服务
+  9. 逐个视图更新，确保每次改动后编译通过
+
+- **验收标准**：
+  - `xcodebuild -project YetAnotherEBookReader.xcodeproj -scheme YetAnotherEBookReader -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17' build` 编译通过
+  - ModelData.swift 行数降至 300 以下
+  - 每个新服务类不超过 500 行
+  - 所有原有功能保持不变（手动冒烟测试）
+
+- **注意事项**：
+  - `@EnvironmentObject var modelData: ModelData` 在视图中仍然可用，但具体操作委托给子服务
+  - Combine Subject 的订阅关系需要仔细梳理，确保服务间的事件传递不中断
+  - `SaveBooksMetadataRealmQueue` 等静态属性需移至对应的服务类
+  - 分步提取，每步确保编译通过后再继续
+
+---
+
+### P0-2：建立测试基础设施
+
+- **涉及文件**：
+  - [YetAnotherEBookReaderTests/](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReaderTests/) (扩充)
+  - 新建测试辅助文件
+  - [ModelData.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Models/ModelData.swift) (提取协议)
+
+- **当前状态**：
+  ```swift
+  // LibrarySearchServiceV2Tests.swift — 唯一的测试文件
+  import XCTest
+  class LibrarySearchServiceV2Tests: XCTestCase {
+      func testExample() throws {
+          // 空的占位测试
+      }
+  }
+  ```
+
+- **目标状态**：
+  ```swift
+  // TestHelpers/RealmTestHelper.swift
+  class RealmTestHelper {
+      static func inMemoryRealm() -> Realm {
+          let config = Realm.Configuration(inMemoryIdentifier: UUID().uuidString)
+          return try! Realm(configuration: config)
+      }
+  }
+  
+  // TestHelpers/MockCalibreServerService.swift
+  class MockCalibreServerService: CalibreServerServiceProtocol {
+      var searchResult: Result<[CalibreBook], Error> = .success([])
+      func searchBooks(...) async throws -> [CalibreBook] { ... }
+  }
+  
+  // CalibreServerManagerTests.swift
+  class CalibreServerManagerTests: XCTestCase {
+      func testAddServer_savesToRealm() { ... }
+      func testRemoveServer_cleansUpLibraries() { ... }
+  }
+  
+  // CalibreBookManagerTests.swift
+  class CalibreBookManagerTests: XCTestCase {
+      func testSaveBooksMetadata_writesToRealm() { ... }
+      func testGetBook_returnsCorrectBook() { ... }
+  }
+  ```
+
+- **执行步骤**：
+  1. 为关键服务类定义协议（Protocol），使其可被 Mock
+  2. 创建 `TestHelpers/` 目录，实现 `RealmTestHelper`（内存 Realm）
+  3. 创建 `MockCalibreServerService` 等 Mock 类
+  4. 为 P0-1 提取出的每个服务类编写基础单元测试（CRUD 操作）
+  5. 为 `CalibreServerService` 的 API 解析逻辑编写测试（使用本地 JSON fixtures）
+  6. 配置 CI 脚本运行测试
+
+- **验收标准**：
+  - `xcodebuild test -project YetAnotherEBookReader.xcodeproj -scheme YetAnotherEBookReader -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17'` 全部通过
+  - 至少覆盖每个新服务类的核心 CRUD 方法
+  - Mock 基础设施可复用
+
+- **注意事项**：
+  - 优先测试数据层和网络解析，UI 测试可后续补充
+  - Realm 测试必须使用 inMemory 配置，避免测试间干扰
+  - 此任务应与 P0-1 并行或紧随其后
+
+---
+
+### P0-3：引入 Repository 层隔离 Realm
+
+- **涉及文件**：
+  - 新建 `Models/Repositories/` 目录
+  - 36 个导入 RealmSwift 的文件 (移除视图层的 Realm 依赖)
+  - [RealmModel.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Models/RealmModel.swift) (保留，但通过 Repository 访问)
+
+- **当前状态**：
+  ```swift
+  // BookDetailView.swift — 视图直接操作 Realm
+  import RealmSwift
+  
+  struct BookDetailView: View {
+      @EnvironmentObject var modelData: ModelData
+      
+      var body: some View {
+          // 直接查询 Realm
+          let results = modelData.realm.objects(CalibreBookRealm.self)
+              .filter("id == %@", bookId)
+          // 直接写入 Realm
+          try! modelData.realm.write {
+              realmBook.lastRead = Date()
+          }
+      }
+  }
+  ```
+
+- **目标状态**：
+  ```swift
+  // Models/Repositories/BookRepository.swift
+  protocol BookRepositoryProtocol {
+      func getBook(id: String) -> CalibreBook?
+      func saveBooks(_ books: [CalibreBook]) throws
+      func deleteBook(id: String) throws
+      func observeBooks() -> AnyPublisher<[CalibreBook], Never>
+  }
+  
+  class RealmBookRepository: BookRepositoryProtocol {
+      private let realm: Realm
+      
+      func getBook(id: String) -> CalibreBook? {
+          guard let realmBook = realm.object(ofType: CalibreBookRealm.self, forPrimaryKey: id)
+          else { return nil }
+          return CalibreBook(from: realmBook)  // 转换为值类型
+      }
+      // ...
+  }
+  
+  // BookDetailView.swift — 视图不再知道 Realm
+  // import RealmSwift ← 已删除
+  struct BookDetailView: View {
+      @EnvironmentObject var bookManager: CalibreBookManager
+      // 通过 service/repository 访问数据
+  }
+  ```
+
+- **执行步骤**：
+  1. 定义 Repository 协议族：`BookRepository`、`ServerRepository`、`LibraryRepository`、`AnnotationRepository`、`ReadingPositionRepository`
+  2. 实现 Realm 版本的每个 Repository
+  3. 将 Realm ↔ 值类型转换逻辑集中到 Repository 内部
+  4. 将 P0-1 提取的服务类改为通过 Repository 访问数据，而非直接操作 Realm
+  5. 逐步从视图文件中移除 `import RealmSwift`
+  6. 确保视图层仅使用值类型（struct）而非 Realm Object
+
+- **验收标准**：
+  - 编译通过
+  - `Views/` 目录下的文件不再包含 `import RealmSwift`
+  - 所有 Realm 操作集中在 `Models/Repositories/` 中
+  - 可以编写使用 Mock Repository 的单元测试
+
+- **注意事项**：
+  - 这是最大改动量的任务，建议与 P0-1 交叉进行
+  - Realm 的 Notification Token（观察变化）需要封装在 Repository 的 Combine Publisher 中
+  - `Providers.swift` 中的 FolioReaderKit Provider 需要特殊处理，因为 FolioReaderKit 可能要求特定的数据访问模式
+  - 分模块推进：先 Book → Server → Library → Annotation
+
+---
+
+## 五、与 FolioReaderKit / Readium 的关系图
+
+### App 层调用 FolioReaderKit 的所有入口点
+
+```mermaid
+graph TD
+    A["YabrEBookReader.swift<br/>(Reader 路由)"] -->|"ReaderType.FOLIOREADER"| B["EpubFolioReaderContainer.swift<br/>(UIViewControllerRepresentable)"]
+    B --> C["FolioReaderViewController.swift<br/>(UIViewController)"]
+    C --> D["FolioReaderContainer<br/>(FolioReaderKit 内部)"]
+    
+    E["Configuration.swift"] -->|"创建 FolioReaderConfig"| D
+    F["Providers.swift"] -->|"实现 FolioReaderBookProvider<br/>FolioReaderHighlightProvider<br/>FolioReaderPositionProvider"| D
+    G["MyFolioReaderCenterDelegate.swift"] -->|"实现 FolioReaderCenterDelegate"| D
+    
+    F -->|"Realm 读写"| H["RealmModel.swift<br/>(BookHighlightRealm,<br/>BookDeviceReadingPositionRealm)"]
+    
+    style A fill:#4CAF50,color:#fff
+    style F fill:#FF9800,color:#fff
+    style H fill:#F44336,color:#fff
+```
+
+**FolioReaderKit 导入文件清单**：
+
+| 文件 | 用途 |
+|------|------|
+| [Configuration.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/FolioReaderView/Configuration.swift) | 创建 `FolioReaderConfig` 配置对象 |
+| [EpubFolioReaderContainer.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/FolioReaderView/EpubFolioReaderContainer.swift) | `UIViewControllerRepresentable` 包装 |
+| [Providers.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/FolioReaderView/Providers.swift) | 实现 FolioReaderKit 的数据 Provider 协议 |
+| [MyFolioReaderCenterDelegate.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/FolioReaderView/MyFolioReaderCenterDelegate.swift) | 页面翻转回调 |
+| [FolioReaderViewController.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/ViewController/FolioReaderViewController.swift) | UIKit 生命周期管理 |
+| [MyReaderViewController.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/ViewController/MyReaderViewController.swift) | 基础 VC 子类 |
+| [YabrEBookReader.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/Reader/YabrEBookReader.swift) | 阅读器路由（选择引擎） |
+
+### App 层调用 Readium 的所有入口点
+
+```mermaid
+graph TD
+    A["YabrEBookReader.swift<br/>(Reader 路由)"] -->|"ReaderType.READIUM"| B["YabrReadiumReaderViewController.swift<br/>(基类, 747行)"]
+    B --> C["YabrReadiumEPUBViewController.swift<br/>(EPUB 特化, 162行)"]
+    B --> D["YabrReadiumPDFViewController.swift<br/>(PDF 特化, 51行)"]
+    
+    C -->|"创建"| E["EPUBNavigatorViewController<br/>(ReadiumNavigator)"]
+    D -->|"创建"| F["PDFNavigatorViewController<br/>(ReadiumNavigator)"]
+    
+    G["YabrReaderNavigationView.swift"] -->|"ReadiumShared.Locator"| B
+    H["YabrReaderSettingsView.swift"] -->|"ReadiumNavigator 偏好"| B
+    I["YabrReaderNavigationViewModel.swift"] -->|"ReadiumShared 类型"| B
+    
+    J["RealmModel.swift"] -->|"import ReadiumShared<br/>持久化 Locator"| K["BookDeviceReadingPositionRealm"]
+    L["SupportInfoView.swift"] -->|"import ReadiumShared<br/>版本信息"| M["About 页面"]
+    
+    style A fill:#4CAF50,color:#fff
+    style J fill:#F44336,color:#fff
+    style B fill:#FF9800,color:#fff
+```
+
+**Readium 模块导入文件清单**：
+
+| 文件 | 导入模块 | 用途 |
+|------|---------|------|
+| [YabrReadiumReaderViewController.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/ReadiumView/YabrReadiumReaderViewController.swift) | ReadiumShared, ReadiumNavigator | Navigator 管理、Publication 处理 |
+| [YabrReadiumEPUBViewController.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/ReadiumView/YabrReadiumEPUBViewController.swift) | ReadiumShared, ReadiumNavigator | EPUB Navigator 创建 |
+| [YabrReadiumPDFViewController.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/ReadiumView/YabrReadiumPDFViewController.swift) | ReadiumShared, ReadiumNavigator | PDF Navigator 创建 |
+| [YabrReaderNavigationView.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/Reader/YabrReaderNavigationView.swift) | ReadiumShared, ReadiumNavigator | TOC 导航 UI |
+| [YabrReaderSettingsView.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/Reader/YabrReaderSettingsView.swift) | ReadiumShared, ReadiumNavigator | 阅读偏好设置 |
+| [YabrReaderNavigationViewModel.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/Reader/YabrReaderNavigationViewModel.swift) | ReadiumShared, ReadiumNavigator | 导航状态管理 |
+| [RealmModel.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Models/RealmModel.swift) | ReadiumShared, ReadiumNavigator | Locator 序列化到 Realm |
+| [YabrEBookReader.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/Reader/YabrEBookReader.swift) | ReadiumShared | Locator 类型 |
+| [EpubFolioReaderContainer.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/FolioReaderView/EpubFolioReaderContainer.swift) | ReadiumShared | Locator 类型（FolioReader 也使用） |
+| [SupportInfoView.swift](file:///Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/SettingsView/SupportInfoView.swift) | ReadiumShared | SDK 版本号展示 |
+
+### Patches 目录分析
+
+项目的 `Libs/` 目录包含三个本地库：
+- `HAControls` — UI 控件
+- `SMSegmentView` — 分段控件
+- `ZFDragableModalTransition` — 模态转场
+
+这些是 **通用 UI 组件的本地拷贝**，非 FolioReaderKit/Readium 的 patch。
+
+FolioReaderKit 本身通过 **SPM 的 fork 引用**（非标准版本），意味着对 FolioReaderKit 的修改直接在 fork 仓库中。需要检查 fork 与上游的差异来确定哪些 patch 应该回归上游。
+
+### 升级 FolioReaderKit 版本的风险点
+
+| 风险 | 严重程度 | 说明 |
+|------|---------|------|
+| Provider 协议变更 | 🔴 高 | `Providers.swift` 的 857 行实现了自定义 Provider 协议，协议签名变化会导致大量修改 |
+| 配置 API 变化 | 🟡 中 | `Configuration.swift` 直接设置 FolioReaderKit 内部属性 |
+| 委托协议变化 | 🟡 中 | `MyFolioReaderCenterDelegate` 实现可能需要更新 |
+| 数据格式兼容性 | 🔴 高 | 高亮和书签的存储格式可能变化 |
+
+### 升级 Readium 版本的风险点
+
+| 风险 | 严重程度 | 说明 |
+|------|---------|------|
+| `Locator` 类型变化 | 🔴 高 | `RealmModel.swift` 将 `Locator` 序列化到 Realm，类型变化需要数据迁移 |
+| Navigator API 变化 | 🔴 高 | `YabrReadiumReaderViewController` (747行) 大量使用 Navigator API |
+| Publication API 变化 | 🟡 中 | Publication 打开和解析流程可能变化 |
+| 偏好 API 变化 | 🟡 中 | `YabrReaderSettingsView` 使用 Readium 偏好系统 |
+
+---
+
+## 六、建议的重构顺序
+
+```
+第1周 ─── 基础建设 ──────────────────────────────────────────
+├── [P0-2] 建立测试基础设施
+│   ├── 创建 TestHelpers（MockRealm, MockServices）
+│   └── 为现有关键路径写 smoke test
+├── [P1-快修] 修复 DSReaderHelperConnector.main.sync 死锁 (A09)
+└── [P2] 清理所有废弃代码 (A07+A13+A22) — 低风险，快速减负
+    ├── 删除 Providers.swift L330-700 废弃代码
+    ├── 删除 Book.swift 4 个废弃结构体
+    └── 清理 CalibreSearchCache 废弃属性
+
+第2周 ─── ModelData 拆分（第一阶段）────────────────────────
+├── [P0-1a] 提取 CalibreServerManager
+├── [P0-1b] 提取 CalibreLibraryManager
+├── [P0-1c] 提取 WebServerService
+└── 持续为提取的服务编写测试
+
+第3周 ─── ModelData 拆分（第二阶段）+ Repository 启动 ──────
+├── [P0-1d] 提取 CalibreBookManager
+├── [P0-1e] 提取 ReadingPositionService
+├── [P0-3a] 引入 BookRepository（首个 Repository）
+└── 开始从 BookDetailView 移除 import RealmSwift
+
+第4周 ─── Repository 层推广 + 阅读器抽象 ────────────────────
+├── [P0-3b] 引入 ServerRepository, LibraryRepository
+├── [P0-3c] 引入 AnnotationRepository
+├── [P1a] 定义统一的 ReaderPositionService 协议
+│   └── 合并三引擎的位置保存逻辑 (A06)
+└── 持续移除视图层 RealmSwift 依赖
+
+第5周 ─── 阅读器重构 + 网络层 ──────────────────────────────
+├── [P1b] 拆分 YabrPDFViewController (A03)
+│   ├── 提取 PDFAnnotationManager
+│   ├── 提取 PDFBookmarkManager
+│   └── 提取 PDFSearchController
+├── [P1c] 统一阅读器主题/高亮抽象 (A14+A15)
+└── [P1d] 重构 CalibreServerService (A04)
+    ├── 引入 CalibreAPIError 统一错误类型
+    └── 按端点拆分方法
+
+第6周 ─── CalibreBrowser + ViewModel + 收尾 ───────────────
+├── [P1e] 完成 V2 迁移，废弃 CalibreBrowser V1 (A02+A18)
+├── [P1f] 为 BookDetailView, LibraryInfoBookListView 引入 ViewModel (A08)
+├── [P2] 拆分 CalibreData.swift (A11)
+├── [P2] 移动 ShelfDataManager 到 Models (A10)
+└── 全面回归测试
+```
+
+### 依赖关系图
+
+```mermaid
+graph LR
+    P0_2["P0-2 测试基础设施"] --> P0_1["P0-1 拆分 ModelData"]
+    P0_1 --> P0_3["P0-3 Repository 层"]
+    P0_3 --> P1_Reader["P1 统一阅读器抽象"]
+    P0_3 --> P1_PDF["P1 拆分 PDFViewController"]
+    P0_1 --> P1_Network["P1 重构 ServerService"]
+    P0_3 --> P1_VM["P1 引入 ViewModel"]
+    P0_3 --> P1_CB["P1 完成 V2 迁移"]
+    P1_VM --> P2_View["P2 拆分超大视图"]
+    P1_CB --> P2_Data["P2 拆分 CalibreData"]
+    
+    style P0_2 fill:#F44336,color:#fff
+    style P0_1 fill:#F44336,color:#fff
+    style P0_3 fill:#F44336,color:#fff
+    style P1_Reader fill:#FF9800,color:#fff
+    style P1_PDF fill:#FF9800,color:#fff
+    style P1_Network fill:#FF9800,color:#fff
+    style P1_VM fill:#FF9800,color:#fff
+    style P1_CB fill:#FF9800,color:#fff
+    style P2_View fill:#4CAF50,color:#fff
+    style P2_Data fill:#4CAF50,color:#fff
+```
+
+> **关键路径**：P0-2 → P0-1 → P0-3 → P1 (并行) → P2 (并行)
+> 
+> 每个阶段完成后应通过 `xcodebuild build` 验证编译通过，并运行已有测试确保无回归。

--- a/REFACTOR_PLAN.md
+++ b/REFACTOR_PLAN.md
@@ -1,0 +1,156 @@
+# 📚 YetAnotherEBookReader 架构重构计划 (REFACTOR_PLAN.md)
+
+## 一、项目现状速览
+
+### 核心目录结构
+当前项目业务逻辑主要集中在以下核心目录，呈现出典型的按照功能而非业务域划分的特征：
+- **`Models/`**: 数据流中心。包含重灾区 `ModelData.swift`（God Object 全局状态引擎）、Realm 数据库交互模块。
+- **`Network/`**: 网络层。包含 `CalibreServerService.swift`（Calibre API 通信）和相关的下载管理器。
+- **`Views/`**: UI 界面展示层。混杂了庞大的基础 SwiftUI 视图（如 `BookDetailView.swift`）和针对第三方阅读器引擎的二次封装（`FolioReaderView/`、`ReadiumView/`、`PDFView/`）。
+- **`ViewController/`**: 历史遗留框架或必须使用 UIKit 桥接的底层逻辑。
+
+### 技术债总量估算
+- **代码总量**：约 30,000 行纯 Swift 代码（不含测试和子模块）。
+- **头部巨石文件 (Massive Files)**：
+  1. `ModelData.swift` (2180 行)：包含了几乎所有全局状态。
+  2. `CalibreBrowser.swift` (2136 行)：耦合了复杂的检索逻辑和UI流。
+  3. `YabrPDFViewController.swift` (1716 行)：业务与底层的强耦合点。
+  4. `CalibreData.swift` (1542 行) & `CalibreServerService.swift` (1388 行)：Calibre 相关业务过于庞大。
+- **问题类型分布**：架构职责边界模糊（45%）、视图逻辑与数据拉取深度耦合（30%）、底层第三方库（阅读器）抽象泄露与强绑定（20%）、跨端适配（Catalyst）逻辑散落（5%）。
+
+---
+
+## 二、架构问题清单
+
+### [P0-1] 全局 God Object `ModelData.swift`
+- **位置**：`/Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Models/ModelData.swift` (Line 20-150)
+- **现象**：作为系统唯一的 `@EnvironmentObject`，包含了多达几十个 `@Published` 属性。既有纯 UI 状态（`activeTab`）、设备信息（`deviceName`），又涵盖了 Realm 数据库对象、网络通讯（`calibreServers`）以及下载管理。
+- **影响**：完全打破了单一职责原则。任何一个局部状态的改变（如背景下载进度变化），都有可能导致依赖了 `ModelData` 的所有根视图树被迫重建刷新，是性能瓶颈与多线程竞态条件的核心元凶。
+- **严重程度**：🔴 高
+
+### [P0-2] 极度臃肿的 PDF 视图控制器
+- **位置**：`/Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/PDFView/YabrPDFViewController.swift` (全文件，共计 1716 行)
+- **现象**：将 `PDFKit` 原生交互手势、高亮生成算法、坐标轴转换逻辑，以及直接与 CoreData/Realm 通信存储书签的行为全部糅合在一个 Controller 里。
+- **影响**：代码复杂度极高，难以单独为其编写单元测试。UI 逻辑和数据库读写混合，导致后期扩展 PDF 标注能力或重构数据库层时极易引发 Bug。
+- **严重程度**：🔴 高
+
+### [P1-1] 缺乏阅读器抽象层（被引擎绑架）
+- **位置**：`/Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/FolioReaderView/EpubFolioReaderContainer.swift` & `/ViewController/FolioReaderViewController.swift`
+- **现象**：业务层直接重写并持有 `FolioReaderKit` 以及 `Readium` 的底层具体类（如 `FolioReaderConfig` 的直接注入）。数据模型转换（进度、高亮）直接通过内部的自定义 Delegate 修改 Realm 数据库，跨越了应有的业务层。
+- **影响**：如果未来需要平滑迁移到纯 Readium 架构，或者更新底层框架，都需要大面积修改视图层代码，架构弹性极差。
+- **严重程度**：🟡 中
+
+### [P1-2] SwiftUI 视图大爆炸
+- **位置**：`/Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/Views/BookDetailView/BookDetailView.swift` (全文件，802 行)
+- **现象**：单一 SwiftUI 文件的 `body` 块嵌套层级过深，充斥着复杂的 `if-else` 条件判断、内联的 ViewModel 逻辑、以及 `#if canImport(GoogleMobileAds)` 这样的外部广告宏命令。
+- **影响**：UI 难以调整，难以复用。开发者阅读代码时大脑堆栈极易溢出。
+- **严重程度**：🟡 中
+
+### [P2-1] macOS Catalyst 适配呈碎片化
+- **位置**：`/Users/peterlee/git/YetAnotherEBookReader/YetAnotherEBookReader/MainView.swift` 及各大基础组件
+- **现象**：没有使用统一的平台差异抽象策略，而是依赖散落在业务代码中的 `@available(macCatalyst 14.0, *)` 进行方法分发。
+- **影响**：Catalyst 版本本质上是 iPad UI 的平移，未能充分利用 macOS 的原生 Menu Bar、多窗口与触控板优势；代码不优雅。
+- **严重程度**：🟢 低
+
+---
+
+## 三、重构优先级矩阵
+
+| 优先级 | 问题编号 | 任务描述 | 影响范围 | 难度 | 预计改动文件数 |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| **P0** | P0-1 | 拆解 `ModelData.swift` 为独立的模块化 Service | 全局 (极广) | 高 | 50+ |
+| **P0** | P0-2 | 重构 `YabrPDFViewController`，抽离 ViewModel | 局部 (PDF模块) | 中 | 10-15 |
+| **P1** | P1-1 | 建立 Reader 协议抽象层，隔离第三方阅读器引擎 | 核心 (广) | 高 | 20+ |
+| **P1** | P1-2 | `BookDetailView.swift` 等庞大 UI 的组件化与 VM 提取 | 局部 (UI) | 低 | 5-10 |
+| **P2** | P2-1 | 抽象 Platform Adapter，集中处理跨平台体验分歧 | 跨端适配 | 中 | ~15 |
+
+---
+
+## 四、P0 任务详细说明
+
+### P0-1：拆解 ModelData God Object
+
+- **涉及文件**：
+  - `YetAnotherEBookReader/Models/ModelData.swift`
+  - `YetAnotherEBookReader/YetAnotherEBookReaderApp.swift`
+  - 各类依赖 `@EnvironmentObject` 的基础视图层。
+- **当前状态**：
+  ```swift
+  class ModelData: ObservableObject {
+      @Published var activeTab = 0
+      @Published var calibreServers = [String: CalibreServer]()
+      @Published var updatingMetadata = false 
+      // 几千行的逻辑混合
+  }
+  ```
+- **目标状态**：按业务域进行依赖反转和状态切分：
+  1. `AppState`: 只管纯 UI 层级的全局状态交互。
+  2. `DBManager`: 负责管理 Realm/DB 数据生命周期。
+  3. `NetworkSyncService`: 负责 Calibre 状态管理。
+- **执行步骤**：
+  1. 新建对应的三个独立 `ObservableObject` 服务类。
+  2. 采用 Facade 模式或直接在 `App` 入口将新服务通过 `.environmentObject()` 分别注入。
+  3. 检索全库的 `var modelData: ModelData`，依据具体视图需要的领域数据，替换为对应的新注入对象（缩小视图的数据订阅范围）。
+  4. 迁移完成后删除原有的 `ModelData` 定义。
+- **验收标准**：
+  - `xcodebuild -scheme YetAnotherEBookReader -sdk iphonesimulator build` 编译 0 报错。
+  - 在 Instruments 中观察 SwiftUI 的 View 刷新频次（Redraw），在进行网络下载时，阅读器界面和书架列表不会发生非预期的全量重绘。
+- **注意事项**：Realm 对象存在严格的线程安全机制约束。迁移网络和数据库状态时，必须确保数据分发的队列（`DispatchQueue.main`）处理正确。
+
+### P0-2：重构 YabrPDFViewController 抽离业务逻辑
+
+- **涉及文件**：
+  - `YetAnotherEBookReader/Views/PDFView/YabrPDFViewController.swift`
+  - (新建) `YetAnotherEBookReader/Views/PDFView/YabrPDFViewModel.swift`
+- **当前状态**：Controller 承担了所有的 PDFKit 手势操作代理、标注信息的解析以及利用 `RealmModel` 直接存储的操作，逻辑完全杂糅。
+- **目标状态**：ViewController 仅作为 View 的代理与渲染层；新增的 `YabrPDFViewModel` 作为大脑管理进度与标注数据。
+- **执行步骤**：
+  1. 创建 `YabrPDFViewModel` 类。
+  2. 将 `YabrPDFViewController` 中的书签读取、高亮创建、坐标系数据持久化逻辑抽离并平移至 ViewModel 中。
+  3. 利用 Combine（或 async/await）将 ViewModel 的数据变动绑定回 ViewController。
+- **验收标准**：
+  - `YabrPDFViewController.swift` 文件行数降低至约 600 行以内。
+  - 能够针对 ViewModel 的书签转化逻辑编写初步的 XCTest 单元测试。
+- **注意事项**：PDFKit 渲染性能敏感，确保抽离的过程中不会破坏既有的高亮选区坐标换算机制。
+
+---
+
+## 五、与 FolioReaderKit / Readium 的关系图
+
+### 1. App 层调用入口与流向
+```mermaid
+graph TD
+    App[D.S.Reader App 层] -->|通过 Delegate 回调| DB[(Realm DB)]
+    App -->|直接强转/组合| Folio[FolioReaderKit]
+    App -->|直接强转/组合| Readium[Readium R2 SDK]
+
+    Folio -->|FolioReaderConfig| Config[硬编码组装]
+    Readium -->|ReadiumNavigator| DirectNav[阅读器控制器直接调用]
+```
+- 主要入口点在 `EpubFolioReaderContainer.swift` 与 `YabrReadiumEPUBViewController.swift` 中，App 直接暴露了第三方引擎的底层 API 并依赖其生命周期。
+
+### 2. Upstream (上游) 与 Patches 的风险
+- `FolioReaderKit` 目前几乎属于停止维护状态，项目中肯定存在私有修改（排版修复等）。如果强行升级该库版本，或者迁移 Swift Toolchain，会面临编译彻底崩溃的风险。
+- **建议**：梳理由于修缮中日韩排版而修改过的 Folio 源码，封装隔离为一个抽象 `Protocol`。长远计划应全面逐步拥抱 `Readium` 或基于 `WebView` 的新型渲染方案。
+
+---
+
+## 六、建议的重构顺序
+
+本着“影响面由高到低，保证应用不崩溃”的原则，提供以下线性执行路径：
+
+- **第 1 周：基础设施清洗 (P0-1)**
+  - 核心：执行 `ModelData.swift` 的降解手术。
+  - 目标：将全局单例变成职责分明的 Services。解决历史顽疾（意外刷新导致的 UI 闪烁和卡顿）。
+
+- **第 2 周：巨型模块拆解 (P0-2, P1-2)**
+  - 核心：拆分 `YabrPDFViewController.swift` 和 `BookDetailView.swift`。
+  - 目标：引入严格的 MVVM 分层，剥离 `View` 与 `Data Fetch` 的耦合，提升代码的可读性和测试性。
+
+- **第 3 周：阅读器底座抽象化 (P1-1)**
+  - 核心：引入 `ReaderEngine` 抽象层协议，统一 `FolioReaderKit` 与 `Readium` 的对外接口（如同页码流转、高亮数据模型）。
+  - 目标：打破与框架的强耦合，为将来彻底淘汰 `FolioReaderKit` 做好平滑的过渡准备。
+
+- **第 4 周：Mac Catalyst 专项优化与去宏化 (P2-1)**
+  - 核心：抽离 `PlatformUIAdaptor`，将所有的 `@available(macCatalyst 14.0, *)` 集中管理。
+  - 目标：提升代码整洁度，为 Mac 用户交付更纯正的原生桌面交互体验。

--- a/YetAnotherEBookReader.xcodeproj/project.pbxproj
+++ b/YetAnotherEBookReader.xcodeproj/project.pbxproj
@@ -165,6 +165,9 @@
 		E70A25CE2F7D1A5D004F006E /* YabrReaderNavigationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E70A25CC2F7D1A5D004F006E /* YabrReaderNavigationViewModel.swift */; };
 		E70A25D02F7D1A69004F006E /* YabrReaderNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E70A25CF2F7D1A69004F006E /* YabrReaderNavigationView.swift */; };
 		E70A25D12F7D1A69004F006E /* YabrReaderNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E70A25CF2F7D1A69004F006E /* YabrReaderNavigationView.swift */; };
+		E71F34862FD3AED3007AB0B1 /* BookDetailViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71F34852FD3AED3007AB0B1 /* BookDetailViewModelTests.swift */; };
+		E71F34882FD3B23D007AB0B1 /* BookDetailSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71F34872FD3B23D007AB0B1 /* BookDetailSubviews.swift */; };
+		E71F34892FD3B23D007AB0B1 /* BookDetailSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71F34872FD3B23D007AB0B1 /* BookDetailSubviews.swift */; };
 		E730405828E865550013BA01 /* YabrEBookReaderMetaSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = E730405728E865550013BA01 /* YabrEBookReaderMetaSource.swift */; };
 		E730405C28EBDAB50013BA01 /* BookAnnotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E730405B28EBDAB50013BA01 /* BookAnnotation.swift */; };
 		E732E3ED2A3F03350075D1AC /* BookDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7804CCD29D138980066BD43 /* BookDetailView.swift */; };
@@ -350,6 +353,8 @@
 		E70A25C92F7BDC8D004F006E /* YabrReaderSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YabrReaderSettingsView.swift; sourceTree = "<group>"; };
 		E70A25CC2F7D1A5D004F006E /* YabrReaderNavigationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YabrReaderNavigationViewModel.swift; sourceTree = "<group>"; };
 		E70A25CF2F7D1A69004F006E /* YabrReaderNavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YabrReaderNavigationView.swift; sourceTree = "<group>"; };
+		E71F34852FD3AED3007AB0B1 /* BookDetailViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookDetailViewModelTests.swift; sourceTree = "<group>"; };
+		E71F34872FD3B23D007AB0B1 /* BookDetailSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookDetailSubviews.swift; sourceTree = "<group>"; };
 		E730405728E865550013BA01 /* YabrEBookReaderMetaSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YabrEBookReaderMetaSource.swift; sourceTree = "<group>"; };
 		E730405B28EBDAB50013BA01 /* BookAnnotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookAnnotation.swift; sourceTree = "<group>"; };
 		E738C89E29160AA700A4AC6E /* CalibreBrowser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalibreBrowser.swift; sourceTree = "<group>"; };
@@ -686,6 +691,7 @@
 			children = (
 				2AC3EC3225BDBC11004A6633 /* YetAnotherEBookReaderTests.swift */,
 				2AC3EC3425BDBC11004A6633 /* Info.plist */,
+				E71F34852FD3AED3007AB0B1 /* BookDetailViewModelTests.swift */,
 			);
 			path = YetAnotherEBookReaderTests;
 			sourceTree = "<group>";
@@ -725,6 +731,7 @@
 			isa = PBXGroup;
 			children = (
 				2A270B24272F7E07006552A3 /* ActivityList.swift */,
+				E71F34872FD3B23D007AB0B1 /* BookDetailSubviews.swift */,
 				E7804CCD29D138980066BD43 /* BookDetailView.swift */,
 				2AA07E9026D73239008CE451 /* BookDetailViewModel.swift */,
 				2AA07E9226DB4ADD008CE451 /* BookPreviewView.swift */,
@@ -984,6 +991,7 @@
 				2A78A6322717D96000A81E53 /* BookImportPicker.swift in Sources */,
 				2A0A78A126EB2AC300F3C753 /* PDFPageWithBackground.swift in Sources */,
 				2A0EBA86267893740080BF5B /* Downloader.swift in Sources */,
+				E71F34882FD3B23D007AB0B1 /* BookDetailSubviews.swift in Sources */,
 				E730405828E865550013BA01 /* YabrEBookReaderMetaSource.swift in Sources */,
 				E792C7E22F83F1EE0015E020 /* YabrAppInfo.swift in Sources */,
 				2A8C26B525C54BC800FC7FC0 /* WebViewUIVC.swift in Sources */,
@@ -1081,6 +1089,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E71F34862FD3AED3007AB0B1 /* BookDetailViewModelTests.swift in Sources */,
 				2AC3EC3325BDBC11004A6633 /* YetAnotherEBookReaderTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1111,6 +1120,7 @@
 				E732E3F02A3F03350075D1AC /* LibraryInfoCategoryItemsView.swift in Sources */,
 				E732E3F12A3F03350075D1AC /* LibraryInfoBookListInfoView.swift in Sources */,
 				E732E3F22A3F03350075D1AC /* LibraryInfoViewModel.swift in Sources */,
+				E71F34892FD3B23D007AB0B1 /* BookDetailSubviews.swift in Sources */,
 				E732E3F32A3F03350075D1AC /* ReaderOptionsReaderHelpView.swift in Sources */,
 				E792C7E32F83F1EE0015E020 /* YabrAppInfo.swift in Sources */,
 				E732E3F42A3F03350075D1AC /* ReaderOptionsFontHelpView.swift in Sources */,
@@ -1272,7 +1282,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1328,7 +1338,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
@@ -1513,7 +1523,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = L8WKJ3U7UT;
 				INFOPLIST_FILE = YetAnotherEBookReaderTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1535,7 +1545,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = L8WKJ3U7UT;
 				INFOPLIST_FILE = YetAnotherEBookReaderTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/YetAnotherEBookReader.xcodeproj/project.pbxproj
+++ b/YetAnotherEBookReader.xcodeproj/project.pbxproj
@@ -168,6 +168,8 @@
 		E71F34862FD3AED3007AB0B1 /* BookDetailViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71F34852FD3AED3007AB0B1 /* BookDetailViewModelTests.swift */; };
 		E71F34882FD3B23D007AB0B1 /* BookDetailSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71F34872FD3B23D007AB0B1 /* BookDetailSubviews.swift */; };
 		E71F34892FD3B23D007AB0B1 /* BookDetailSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71F34872FD3B23D007AB0B1 /* BookDetailSubviews.swift */; };
+		E71F348B2FD416AA007AB0B1 /* ActivityListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71F348A2FD416AA007AB0B1 /* ActivityListViewModel.swift */; };
+		E71F348C2FD416AA007AB0B1 /* ActivityListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71F348A2FD416AA007AB0B1 /* ActivityListViewModel.swift */; };
 		E730405828E865550013BA01 /* YabrEBookReaderMetaSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = E730405728E865550013BA01 /* YabrEBookReaderMetaSource.swift */; };
 		E730405C28EBDAB50013BA01 /* BookAnnotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E730405B28EBDAB50013BA01 /* BookAnnotation.swift */; };
 		E732E3ED2A3F03350075D1AC /* BookDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7804CCD29D138980066BD43 /* BookDetailView.swift */; };
@@ -355,6 +357,7 @@
 		E70A25CF2F7D1A69004F006E /* YabrReaderNavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YabrReaderNavigationView.swift; sourceTree = "<group>"; };
 		E71F34852FD3AED3007AB0B1 /* BookDetailViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookDetailViewModelTests.swift; sourceTree = "<group>"; };
 		E71F34872FD3B23D007AB0B1 /* BookDetailSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookDetailSubviews.swift; sourceTree = "<group>"; };
+		E71F348A2FD416AA007AB0B1 /* ActivityListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityListViewModel.swift; sourceTree = "<group>"; };
 		E730405728E865550013BA01 /* YabrEBookReaderMetaSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YabrEBookReaderMetaSource.swift; sourceTree = "<group>"; };
 		E730405B28EBDAB50013BA01 /* BookAnnotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookAnnotation.swift; sourceTree = "<group>"; };
 		E738C89E29160AA700A4AC6E /* CalibreBrowser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalibreBrowser.swift; sourceTree = "<group>"; };
@@ -739,6 +742,7 @@
 				2AD38F8626D637B70053D01D /* ReadingPositionDetailView.swift */,
 				2A264A4027311E8200C4CEFA /* ReadingPositionHistoryView.swift */,
 				2AD38F8826D639EE0053D01D /* ReadingPositionViewModel.swift */,
+				E71F348A2FD416AA007AB0B1 /* ActivityListViewModel.swift */,
 			);
 			path = BookDetailView;
 			sourceTree = "<group>";
@@ -1030,6 +1034,7 @@
 				E79360182A08A1B000E0E554 /* LibraryInfoCategoryItemsView.swift in Sources */,
 				2A8C26BA25C54C6B00FC7FC0 /* WebViewUI.swift in Sources */,
 				2AA07E9126D73239008CE451 /* BookDetailViewModel.swift in Sources */,
+				E71F348B2FD416AA007AB0B1 /* ActivityListViewModel.swift in Sources */,
 				E792835928F835FA00EE2FC7 /* YabrPDFThumbnailList.swift in Sources */,
 				2AE26433274B8D4B00DC5806 /* ServerOptionsDSReaderHelper.swift in Sources */,
 				2ABB912A261DE894004AA7C0 /* SectionShelfController.swift in Sources */,
@@ -1159,6 +1164,7 @@
 				6E7B80F028FBA7AD008B075C /* ReaderOptionsFormatHelpView.swift in Sources */,
 				6E7B80F828FBA7AD008B075C /* AddModServerView.swift in Sources */,
 				6E7B80F928FBA7AD008B075C /* ServerDetailView.swift in Sources */,
+				E71F348C2FD416AA007AB0B1 /* ActivityListViewModel.swift in Sources */,
 				6E7B80FA28FBA7AD008B075C /* ServerOptionsDSReaderHelper.swift in Sources */,
 				6E7B80FB28FBA7AD008B075C /* SupportCalibreIntroView.swift in Sources */,
 				6E7B80FC28FBA7AD008B075C /* LibraryDetailView.swift in Sources */,

--- a/YetAnotherEBookReader.xcodeproj/project.pbxproj
+++ b/YetAnotherEBookReader.xcodeproj/project.pbxproj
@@ -734,6 +734,7 @@
 			isa = PBXGroup;
 			children = (
 				2A270B24272F7E07006552A3 /* ActivityList.swift */,
+				E71F348A2FD416AA007AB0B1 /* ActivityListViewModel.swift */,
 				E71F34872FD3B23D007AB0B1 /* BookDetailSubviews.swift */,
 				E7804CCD29D138980066BD43 /* BookDetailView.swift */,
 				2AA07E9026D73239008CE451 /* BookDetailViewModel.swift */,
@@ -742,7 +743,6 @@
 				2AD38F8626D637B70053D01D /* ReadingPositionDetailView.swift */,
 				2A264A4027311E8200C4CEFA /* ReadingPositionHistoryView.swift */,
 				2AD38F8826D639EE0053D01D /* ReadingPositionViewModel.swift */,
-				E71F348A2FD416AA007AB0B1 /* ActivityListViewModel.swift */,
 			);
 			path = BookDetailView;
 			sourceTree = "<group>";

--- a/YetAnotherEBookReader/Models/ModelData.swift
+++ b/YetAnotherEBookReader/Models/ModelData.swift
@@ -1306,9 +1306,11 @@ final class ModelData: ObservableObject, CalibreServerConfigProvider {
             return
         }
         
-        book.formats.filter { $1.cached }.forEach {
-            guard let format = Format(rawValue: $0.key) else { return }
-            clearCache(book: book,  format: format)
+        let cachedFormats = book.formats.filter { $1.cached }
+        for (key, _) in cachedFormats {
+            guard let format = Format(rawValue: key) else { continue }
+            guard let currentBook = booksInShelf[inShelfId] else { continue }
+            clearCache(book: currentBook, format: format)
         }
     }
     
@@ -1360,6 +1362,7 @@ final class ModelData: ObservableObject, CalibreServerConfigProvider {
         newBook.formats[format.rawValue]?.cacheSize = 0
         newBook.formats[format.rawValue]?.cached = false
         newBook.formats[format.rawValue]?.selected = nil
+        newBook.lastUpdated = .init()
 
         updateBook(book: newBook)
         

--- a/YetAnotherEBookReader/Models/RealmModel.swift
+++ b/YetAnotherEBookReader/Models/RealmModel.swift
@@ -67,7 +67,13 @@ extension CalibreServer: Persistable {
 
 extension CalibreServer {
     var realmPerf: Realm {
-        try! Realm(configuration: BookAnnotation.getBookPreferenceServerConfig(self))
+        let key = "realmPerf-\(self.uuid.uuidString)"
+        if let cachedRealm = Thread.current.threadDictionary[key] as? Realm {
+            return cachedRealm
+        }
+        let realm = try! Realm(configuration: BookAnnotation.getBookPreferenceServerConfig(self))
+        Thread.current.threadDictionary[key] = realm
+        return realm
     }
 }
 

--- a/YetAnotherEBookReader/Network/CalibreServerService.swift
+++ b/YetAnotherEBookReader/Network/CalibreServerService.swift
@@ -547,6 +547,7 @@ final class CalibreServerService {
         }
         bookRealm.userMetaData = try? JSONSerialization.data(withJSONObject: userMetadatas, options: [])
         _ = bookRealm.readPos(library: library)
+        bookRealm.lastUpdated = Date()
     }
     
     func getBookManifest(book: CalibreBook, format: Format, completion: ((_ manifest: Data?) -> Void)? = nil) {

--- a/YetAnotherEBookReader/Views/BookDetailView/ActivityList.swift
+++ b/YetAnotherEBookReader/Views/BookDetailView/ActivityList.swift
@@ -4,74 +4,27 @@
 //
 //  Created by 京太郎 on 2021/11/1.
 //
+
 import SwiftUI
-import RealmSwift
 
 struct ActivityList: View {
-    @EnvironmentObject var modelData: ModelData
+    @ObservedObject var viewModel: ActivityListViewModel
 
     @Binding var presenting: Bool
 
-    var libraryId: String? = nil
-    var bookId: Int32? = nil
-
-    @ObservedResults(
-        CalibreActivityLogEntry.self,
-        configuration: ModelData.shared?.realmConf,
-        sortDescriptor: SortDescriptor(keyPath: "startDatetime", ascending: false)
-    ) var activities
-
-    init(presenting: Bool? = nil, libraryId: String? = nil, bookId: Int32? = nil) {
-        self._presenting = Binding<Bool>(get: { presenting ?? false }, set: { _ in })
-        self.libraryId = libraryId
-        self.bookId = bookId
-        
-        let cutoff = Date(timeIntervalSinceNow: -86400 * 7)  // Show last 7 days
-        var predicate = NSPredicate(format: "startDatetime >= %@", cutoff as NSDate)
-        
-        if let libraryId = libraryId {
-            if let bookId = bookId {
-                predicate = NSPredicate(format: "startDatetime >= %@ AND libraryId == %@ AND bookId == %d", cutoff as NSDate, libraryId, bookId)
-            } else {
-                predicate = NSPredicate(format: "startDatetime >= %@ AND libraryId == %@", cutoff as NSDate, libraryId)
-            }
-        }
-        
-        _activities = ObservedResults(
-            CalibreActivityLogEntry.self,
-            configuration: ModelData.shared?.realmConf,
-            filter: predicate,
-            sortDescriptor: SortDescriptor(keyPath: "startDatetime", ascending: false)
-        )
-    }
-    
-    init(presenting: Binding<Bool>, libraryId: String? = nil, bookId: Int32? = nil) {
+    init(viewModel: ActivityListViewModel, presenting: Binding<Bool>) {
+        self.viewModel = viewModel
         self._presenting = presenting
-        self.libraryId = libraryId
-        self.bookId = bookId
-        
-        let cutoff = Date(timeIntervalSinceNow: -86400 * 7)  // Show last 7 days
-        var predicate = NSPredicate(format: "startDatetime >= %@", cutoff as NSDate)
-        
-        if let libraryId = libraryId {
-            if let bookId = bookId {
-                predicate = NSPredicate(format: "startDatetime >= %@ AND libraryId == %@ AND bookId == %d", cutoff as NSDate, libraryId, bookId)
-            } else {
-                predicate = NSPredicate(format: "startDatetime >= %@ AND libraryId == %@", cutoff as NSDate, libraryId)
-            }
-        }
-        
-        _activities = ObservedResults(
-            CalibreActivityLogEntry.self,
-            configuration: ModelData.shared?.realmConf,
-            filter: predicate,
-            sortDescriptor: SortDescriptor(keyPath: "startDatetime", ascending: false)
-        )
+    }
+
+    init(viewModel: ActivityListViewModel, presenting: Bool? = nil) {
+        self.viewModel = viewModel
+        self._presenting = Binding<Bool>(get: { presenting ?? false }, set: { _ in })
     }
 
     var body: some View {
         List {
-            ForEach(activities, id: \.self) { obj in
+            ForEach(viewModel.activities, id: \.self) { obj in
                 NavigationLink(destination: ActivityDetailView(obj: obj), label: {
                     row(obj: obj)
                 })
@@ -95,77 +48,61 @@ struct ActivityList: View {
     }
     
     @ViewBuilder
-    private func row(obj: CalibreActivityLogEntry) -> some View {
+    private func row(obj: ActivityLogUIEntry) -> some View {
         VStack {
             HStack {
-                if let libraryId = obj.libraryId,
-                   let library = modelData.calibreLibraries[libraryId] {
-                    if let book = modelData.queryBookRealm(book: CalibreBook(id: obj.bookId, library: library), realm: modelData.realm) {
-                        Text(book.title)
-                    } else {
-                        Text(library.name)
-                    }
-                } else {
-                    Text("No Entity")
-                }
+                Text(obj.bookTitle.isEmpty ? obj.libraryName : obj.bookTitle)
                 Spacer()
-                
             }
             HStack {
-                Text(obj.type ?? "Unknown Type")
+                Text(obj.type)
                 Spacer()
-                Text(obj.errMsg ?? "Unknown Error")
+                Text(obj.errMsg)
             }.font(.caption)
             HStack {
-                Text(obj.startDateByLocale ?? "Start Unknown")
+                Text(obj.startDateString)
                 Spacer()
                 Text("->")
                 Spacer()
-                Text(obj.finishDateByLocale ?? "Finish Unknown")
+                Text(obj.finishDateString)
             }.font(.caption)
         }
     }
 }
 
 struct ActivityDetailView: View {
-    @EnvironmentObject var modelData: ModelData
-    var obj: CalibreActivityLogEntry
+    var obj: ActivityLogUIEntry
     
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             HStack {
-                if let libraryId = obj.libraryId,
-                   let library = modelData.calibreLibraries[libraryId] {
-                    if let book = modelData.queryBookRealm(book: CalibreBook(id: obj.bookId, library: library), realm: modelData.realm) {
-                        Text("Book Title:").frame(minWidth: 100, alignment: .leading)
-                        Text(book.title)
-                    } else {
-                        Text("Library Name:").frame(minWidth: 100, alignment: .leading)
-                        Text(library.name)
-                    }
+                if !obj.bookTitle.isEmpty {
+                    Text("Book Title:").frame(minWidth: 100, alignment: .leading)
+                    Text(obj.bookTitle)
                 } else {
-                    Text("No Entity")
+                    Text("Library Name:").frame(minWidth: 100, alignment: .leading)
+                    Text(obj.libraryName)
                 }
                 Spacer()
             }.font(.title2)
             HStack {
                 Text("Task:").frame(minWidth: 100, alignment: .leading)
-                Text(obj.type ?? "Unknown").navigationTitle(obj.type ?? "")
+                Text(obj.type).navigationTitle(obj.type)
                 Spacer()
             }.font(.title3)
             HStack {
                 Text("Start time:").frame(minWidth: 100, alignment: .leading)
-                Text(obj.startDateByLocaleLong ?? "Unknown")
+                Text(obj.startDateLongString)
             }
             
             HStack {
                 Text("Finish time:").frame(minWidth: 100, alignment: .leading)
-                Text(obj.finishDateByLocaleLong ?? "Unknown")
+                Text(obj.finishDateLongString)
             }
             
             HStack {
                 Text("Result:").frame(minWidth: 100, alignment: .leading)
-                Text(obj.errMsg ?? "Unknown")
+                Text(obj.errMsg)
             }
             
             Divider().padding(EdgeInsets(top: 16, leading: 0, bottom: 8, trailing: 0))
@@ -174,15 +111,15 @@ struct ActivityDetailView: View {
                 Text("More Infos")
                 HStack {
                     Text("URL:").frame(minWidth: 64, alignment: .leading)
-                    Text(obj.endpoingURL ?? "Unknown")
+                    Text(obj.endpointURL)
                 }
                 HStack {
                     Text("Method:").frame(minWidth: 64, alignment: .leading)
-                    Text(obj.httpMethod ?? "GET")
+                    Text(obj.httpMethod)
                 }
                 HStack(alignment: .top) {
                     Text("Body:").frame(minWidth: 64, alignment: .leading)
-                    if let httpBody = obj.httpBody, let httpBodyString = String(data: httpBody, encoding: .utf8) {
+                    if let httpBodyString = obj.httpBodyString {
                         Text(httpBodyString)
                     } else {
                         Text("(Empty Body)")
@@ -202,9 +139,11 @@ struct ActivityList_Previews: PreviewProvider {
     @State static private var presenting = false
     static var previews: some View {
         NavigationView {
-            ActivityList(presenting: $presenting)
+            ActivityList(
+                viewModel: ActivityListViewModel(modelData: modelData),
+                presenting: $presenting
+            )
         }
         .navigationViewStyle(StackNavigationViewStyle())
-        .environmentObject(modelData)
     }
 }

--- a/YetAnotherEBookReader/Views/BookDetailView/ActivityListViewModel.swift
+++ b/YetAnotherEBookReader/Views/BookDetailView/ActivityListViewModel.swift
@@ -1,0 +1,109 @@
+//
+//  ActivityListViewModel.swift
+//  YetAnotherEBookReader
+//
+//  Created by京太郎 on 2026/06/06.
+//
+
+import Foundation
+import SwiftUI
+import RealmSwift
+
+struct ActivityLogUIEntry: Identifiable, Hashable {
+    let id: String
+    let libraryName: String
+    let bookTitle: String
+    let type: String
+    let errMsg: String
+    let startDateString: String
+    let finishDateString: String
+    let startDateLongString: String
+    let finishDateLongString: String
+    let endpointURL: String
+    let httpMethod: String
+    let httpBodyString: String?
+}
+
+class ActivityListViewModel: ObservableObject {
+    @Published var activities: [ActivityLogUIEntry] = []
+    
+    private var notificationToken: NotificationToken?
+    private let modelData: ModelData
+    private let libraryId: String?
+    private let bookId: Int32?
+    
+    init(modelData: ModelData, libraryId: String? = nil, bookId: Int32? = nil) {
+        self.modelData = modelData
+        self.libraryId = libraryId
+        self.bookId = bookId
+        
+        loadActivities()
+    }
+    
+    func loadActivities() {
+        guard let realm = modelData.realmConf != nil ? try? Realm(configuration: modelData.realmConf!) : modelData.realm else { return }
+        
+        let cutoff = Date(timeIntervalSinceNow: -86400 * 7)  // Show last 7 days
+        var predicate = NSPredicate(format: "startDatetime >= %@", cutoff as NSDate)
+        
+        if let libraryId = libraryId {
+            if let bookId = bookId {
+                predicate = NSPredicate(format: "startDatetime >= %@ AND libraryId == %@ AND bookId == %d", cutoff as NSDate, libraryId, bookId)
+            } else {
+                predicate = NSPredicate(format: "startDatetime >= %@ AND libraryId == %@", cutoff as NSDate, libraryId)
+            }
+        }
+        
+        let results = realm.objects(CalibreActivityLogEntry.self)
+            .filter(predicate)
+            .sorted(byKeyPath: "startDatetime", ascending: false)
+        
+        // Setup observation block to ensure list is updated reactively
+        notificationToken = results.observe { [weak self] changes in
+            guard let self = self else { return }
+            switch changes {
+            case .initial(let collection), .update(let collection, _, _, _):
+                self.activities = collection.map { self.mapToUI($0) }
+            case .error(let error):
+                print("Realm observation error in ActivityListViewModel: \(error)")
+            }
+        }
+    }
+    
+    private func mapToUI(_ obj: CalibreActivityLogEntry) -> ActivityLogUIEntry {
+        var libraryName = "No Entity"
+        var bookTitle = ""
+        
+        if let libraryId = obj.libraryId,
+           let library = modelData.calibreLibraries[libraryId] {
+            libraryName = library.name
+            if let book = modelData.queryBookRealm(book: CalibreBook(id: obj.bookId, library: library), realm: modelData.realm) {
+                bookTitle = book.title
+            }
+        }
+        
+        return ActivityLogUIEntry(
+            id: obj.id,
+            libraryName: libraryName,
+            bookTitle: bookTitle,
+            type: obj.type ?? "Unknown Type",
+            errMsg: obj.errMsg ?? "Unknown Error",
+            startDateString: obj.startDateByLocale ?? "Start Unknown",
+            finishDateString: obj.finishDateByLocale ?? "Finish Unknown",
+            startDateLongString: obj.startDateByLocaleLong ?? "Unknown",
+            finishDateLongString: obj.finishDateByLocaleLong ?? "Unknown",
+            endpointURL: obj.endpoingURL ?? "Unknown",
+            httpMethod: obj.httpMethod ?? "GET",
+            httpBodyString: {
+                if let httpBody = obj.httpBody {
+                    return String(data: httpBody, encoding: .utf8)
+                }
+                return nil
+            }()
+        )
+    }
+    
+    deinit {
+        notificationToken?.invalidate()
+    }
+}

--- a/YetAnotherEBookReader/Views/BookDetailView/BookDetailSubviews.swift
+++ b/YetAnotherEBookReader/Views/BookDetailView/BookDetailSubviews.swift
@@ -3,7 +3,6 @@ import KingfisherSwiftUI
 import RealmSwift
 
 struct BookCoverView: View {
-    @EnvironmentObject var modelData: ModelData
     @EnvironmentObject var downloadManager: BookDownloadManager
     @ObservedObject var viewModel: BookDetailViewModel
     var book: CalibreBook
@@ -47,10 +46,12 @@ struct BookCoverView: View {
             }
             .opacity(0.8)
             .fullScreenCover(isPresented: $presentingReadingSheet) {
-                YabrEBookReader(
-                    book: book,
-                    readerInfo: modelData.prepareBookReading(book: book)
-                )
+                if let readerInfo = viewModel.readerInfo {
+                    YabrEBookReader(
+                        book: book,
+                        readerInfo: readerInfo
+                    )
+                }
             }
         }
         .frame(width: 300, height: 400)
@@ -59,7 +60,6 @@ struct BookCoverView: View {
 
 struct BookMetadataSection: View {
     @Environment(\.openURL) var openURL
-    @EnvironmentObject var modelData: ModelData
     @ObservedObject var viewModel: BookDetailViewModel
     var book: CalibreBook
     var lastUpdated: Date
@@ -197,7 +197,6 @@ struct BookMetadataSection: View {
 }
 
 struct BookProgressSection: View {
-    @EnvironmentObject var modelData: ModelData
     @ObservedObject var viewModel: BookDetailViewModel
     var book: CalibreBook
     var lastUpdated: Date
@@ -228,7 +227,7 @@ struct BookProgressSection: View {
                         .aspectRatio(contentMode: .fit)
                         .frame(width: 20, height: 20)
                     Text("\(readProgressGR)%")
-                } else if let position = book.readPos.getPosition(modelData.deviceName) ?? book.readPos.getDevices().first {
+                } else if let position = book.readPos.getPosition(viewModel.deviceName) ?? book.readPos.getDevices().first {
                     Image(systemName: "book.circle")
                         .resizable()
                         .aspectRatio(contentMode: .fit)
@@ -260,7 +259,7 @@ struct BookProgressSection: View {
 }
 
 struct BookConnectivitySection: View {
-    @EnvironmentObject var modelData: ModelData
+    @ObservedObject var viewModel: BookDetailViewModel
     var book: CalibreBook
     var lastUpdated: Date
     var isCompat: Bool
@@ -270,22 +269,22 @@ struct BookConnectivitySection: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            if modelData.updatingMetadataStatus == "Success" {
+            if viewModel.updatingMetadataStatus == "Success" {
                 HStack {
                     metadataIcon(systemName: "checkmark.shield")
                     Text("In Sync with Server")
                 }
-            } else if modelData.updatingMetadataStatus == "Local File" {
+            } else if viewModel.updatingMetadataStatus == "Local File" {
                 HStack {
                     metadataIcon(systemName: "doc")
                     Text("Local File")
                 }
-            } else if modelData.updatingMetadataStatus == "Deleted" {
+            } else if viewModel.updatingMetadataStatus == "Deleted" {
                 HStack {
                     metadataIcon(systemName: "xmark.shield")
                     Text("Been Deleted on Server")
                 }
-            } else if modelData.updatingMetadataStatus == "Updating" {
+            } else if viewModel.updatingMetadataStatus == "Updating" {
                 HStack {
                     metadataIcon(systemName: "arrow.clockwise")
                     Text("Syncing with Server")
@@ -293,7 +292,7 @@ struct BookConnectivitySection: View {
             } else {
                 VStack(alignment: .trailing, spacing: 4) {
                     Button(action:{
-                        alertItem = AlertItem(id: "Sync Error", msg: modelData.updatingMetadataStatus)
+                        alertItem = AlertItem(id: "Sync Error", msg: viewModel.updatingMetadataStatus)
                     }) {
                         HStack {
                             metadataIcon(systemName: "exclamationmark.shield")
@@ -311,12 +310,14 @@ struct BookConnectivitySection: View {
                 }.sheet(isPresented: $activityListViewPresenting, onDismiss: {
                 }, content: {
                     NavigationView {
-                        ActivityList(presenting: $activityListViewPresenting, libraryId: book.library.id, bookId: book.id)
-                            .environmentObject(modelData)
-                            .environmentObject(modelData.downloadManager)
-                            .environmentObject(modelData.sessionManager)
-                            .environmentObject(modelData.fontsManager)
-                            .environment(\.realmConfiguration, modelData.realmConf ?? Realm.Configuration.defaultConfiguration)
+                        if let modelData = viewModel.sharedModelData {
+                            ActivityList(presenting: $activityListViewPresenting, libraryId: book.library.id, bookId: book.id)
+                                .environmentObject(modelData)
+                                .environmentObject(modelData.downloadManager)
+                                .environmentObject(modelData.sessionManager)
+                                .environmentObject(modelData.fontsManager)
+                                .environment(\.realmConfiguration, modelData.realmConf ?? Realm.Configuration.defaultConfiguration)
+                        }
                     }
                 })
             }
@@ -332,7 +333,6 @@ struct BookConnectivitySection: View {
 }
 
 struct BookFormatList: View {
-    @EnvironmentObject var modelData: ModelData
     @EnvironmentObject var downloadManager: BookDownloadManager
     @ObservedObject var viewModel: BookDetailViewModel
     var book: CalibreBook
@@ -378,16 +378,16 @@ struct BookFormatList: View {
                                 
                                 Button(action: {
                                     if download.isDownloading {
-                                        modelData.pauseDownloadFormat(book: book, format: format)
+                                        viewModel.pauseDownload(book: book, format: format)
                                     } else {
-                                        modelData.resumeDownloadFormat(book: book, format: format)
+                                        viewModel.resumeDownload(book: book, format: format)
                                     }
                                 }) {
                                     Image(systemName: download.isDownloading ? "pause" : "play")
                                 }
                                 
                                 Button(action:{
-                                    modelData.cancelDownloadFormat(book: book, format: format)
+                                    viewModel.cancelDownload(book: book, format: format)
                                 }) {
                                     Image(systemName: "xmark")
                                         .foregroundColor(.red)
@@ -443,7 +443,7 @@ struct BookFormatList: View {
                 .frame(width: 24, height: 24)
         }
         .sheet(isPresented: $presentingPreviewSheet, onDismiss: {
-            modelData.readerInfo = modelData.prepareBookReading(book: book)
+            viewModel.handlePreviewDismiss(book: book)
         }) {
             BookPreviewView(viewModel: viewModel.previewViewModel)
         }

--- a/YetAnotherEBookReader/Views/BookDetailView/BookDetailSubviews.swift
+++ b/YetAnotherEBookReader/Views/BookDetailView/BookDetailSubviews.swift
@@ -7,7 +7,6 @@ struct BookCoverView: View {
     var book: CalibreBook
     var lastUpdated: Date
     
-    @Binding var presentingReadingSheet: Bool
     @Binding var alertItem: AlertItem?
 
     var body: some View {
@@ -22,7 +21,7 @@ struct BookCoverView: View {
                 guard viewModel.activeDownloads.filter({ $1.isDownloading && $1.book.id == book.id }).isEmpty else { return }
                 viewModel.readBook(book: book)
                 if book.inShelf {
-                    presentingReadingSheet = true
+                    viewModel.presentingReadingSheet = true
                 }
             }) {
                 if viewModel.activeDownloads.filter({ $1.book.id == book.id && ($1.isDownloading || $1.resumeData != nil) }).isEmpty == false ||
@@ -44,7 +43,7 @@ struct BookCoverView: View {
                 }
             }
             .opacity(0.8)
-            .fullScreenCover(isPresented: $presentingReadingSheet) {
+            .fullScreenCover(isPresented: $viewModel.presentingReadingSheet) {
                 if let readerInfo = viewModel.readerInfo {
                     YabrEBookReader(
                         book: book,
@@ -64,7 +63,6 @@ struct BookMetadataSection: View {
     var lastUpdated: Date
     var isCompat: Bool
     
-    @Binding var readingPositionHistoryViewPresenting: Bool
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -153,7 +151,7 @@ struct BookMetadataSection: View {
                     Text(book.lastModifiedByLocale)
                 }
                 
-                BookProgressSection(viewModel: viewModel, book: book, lastUpdated: lastUpdated, isCompat: isCompat, readingPositionHistoryViewPresenting: $readingPositionHistoryViewPresenting)
+                BookProgressSection(viewModel: viewModel, book: book, lastUpdated: lastUpdated, isCompat: isCompat)
                 
                 HStack {
                     metadataIcon(systemName: "books.vertical")
@@ -200,8 +198,6 @@ struct BookProgressSection: View {
     var book: CalibreBook
     var lastUpdated: Date
     var isCompat: Bool
-    
-    @Binding var readingPositionHistoryViewPresenting: Bool
 
     var body: some View {
         HStack {
@@ -212,7 +208,7 @@ struct BookProgressSection: View {
             
             Button(action:{
                 viewModel.prepareReadingPositionHistory(book: book)
-                readingPositionHistoryViewPresenting = true
+                viewModel.readingPositionHistoryViewPresenting = true
             }) {
                 if let readDateGR = book.readDateGRByLocale {
                     Image(systemName: "arrow.down.to.line")
@@ -238,15 +234,15 @@ struct BookProgressSection: View {
                     Text("No Reading History")
                 }
             }.disabled(book.readPos.isEmpty)
-        }.sheet(isPresented: $readingPositionHistoryViewPresenting, onDismiss: {
-            readingPositionHistoryViewPresenting = false
+        }.sheet(isPresented: $viewModel.readingPositionHistoryViewPresenting, onDismiss: {
+            viewModel.readingPositionHistoryViewPresenting = false
         }, content: {
             NavigationView {
-                ReadingPositionHistoryView(presenting: $readingPositionHistoryViewPresenting, library: book.library, bookId: book.id)
+                ReadingPositionHistoryView(presenting: $viewModel.readingPositionHistoryViewPresenting, library: book.library, bookId: book.id)
                     .toolbar {
                         ToolbarItem(placement: .cancellationAction, content: {
                             Button(action: {
-                                readingPositionHistoryViewPresenting = false
+                                viewModel.readingPositionHistoryViewPresenting = false
                             }) {
                                 Image(systemName: "xmark")
                             }
@@ -263,7 +259,6 @@ struct BookConnectivitySection: View {
     var lastUpdated: Date
     var isCompat: Bool
     
-    @Binding var activityListViewPresenting: Bool
     @Binding var alertItem: AlertItem?
 
     var body: some View {
@@ -303,14 +298,14 @@ struct BookConnectivitySection: View {
             HStack {
                 metadataIcon(systemName: "scroll")
                 Button(action: {
-                    activityListViewPresenting = true
+                    viewModel.activityListViewPresenting = true
                 }) {
                     Text("Activity Logs")
-                }.sheet(isPresented: $activityListViewPresenting, onDismiss: {
+                }.sheet(isPresented: $viewModel.activityListViewPresenting, onDismiss: {
                 }, content: {
                     NavigationView {
                         if let modelData = viewModel.sharedModelData {
-                            ActivityList(presenting: $activityListViewPresenting, libraryId: book.library.id, bookId: book.id)
+                            ActivityList(presenting: $viewModel.activityListViewPresenting, libraryId: book.library.id, bookId: book.id)
                                 .environmentObject(modelData)
                                 .environmentObject(modelData.downloadManager)
                                 .environmentObject(modelData.sessionManager)
@@ -336,8 +331,6 @@ struct BookFormatList: View {
     var book: CalibreBook
     var lastUpdated: Date
     var isCompat: Bool
-    
-    @Binding var presentingPreviewSheet: Bool
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -432,7 +425,7 @@ struct BookFormatList: View {
     private func previewFormatButton(book: CalibreBook, format: Format, formatInfo: FormatInfo) -> some View {
         Button(action: {
             if viewModel.previewAction(book: book, format: format, formatInfo: formatInfo) {
-                presentingPreviewSheet = true
+                viewModel.presentingPreviewSheet = true
             }
         }) {
             Image(systemName: "doc.text.magnifyingglass")
@@ -440,7 +433,7 @@ struct BookFormatList: View {
                 .aspectRatio(contentMode: .fit)
                 .frame(width: 24, height: 24)
         }
-        .sheet(isPresented: $presentingPreviewSheet, onDismiss: {
+        .sheet(isPresented: $viewModel.presentingPreviewSheet, onDismiss: {
             viewModel.handlePreviewDismiss(book: book)
         }) {
             BookPreviewView(viewModel: viewModel.previewViewModel)

--- a/YetAnotherEBookReader/Views/BookDetailView/BookDetailSubviews.swift
+++ b/YetAnotherEBookReader/Views/BookDetailView/BookDetailSubviews.swift
@@ -3,7 +3,6 @@ import KingfisherSwiftUI
 import RealmSwift
 
 struct BookCoverView: View {
-    @EnvironmentObject var downloadManager: BookDownloadManager
     @ObservedObject var viewModel: BookDetailViewModel
     var book: CalibreBook
     var lastUpdated: Date
@@ -20,13 +19,13 @@ struct BookCoverView: View {
                 .resizable()
                 .scaledToFit()
             Button(action: {
-                guard downloadManager.activeDownloads.filter({ $1.isDownloading && $1.book.id == book.id }).isEmpty else { return }
+                guard viewModel.activeDownloads.filter({ $1.isDownloading && $1.book.id == book.id }).isEmpty else { return }
                 viewModel.readBook(book: book)
                 if book.inShelf {
                     presentingReadingSheet = true
                 }
             }) {
-                if downloadManager.activeDownloads.filter({ $1.book.id == book.id && ($1.isDownloading || $1.resumeData != nil) }).isEmpty == false ||
+                if viewModel.activeDownloads.filter({ $1.book.id == book.id && ($1.isDownloading || $1.resumeData != nil) }).isEmpty == false ||
                     book.formats.filter({ $0.value.selected == true && $0.value.cached == false }).isEmpty == false {
                     ProgressView()
                         .progressViewStyle(CircularProgressViewStyle(tint: .gray))
@@ -333,7 +332,6 @@ struct BookConnectivitySection: View {
 }
 
 struct BookFormatList: View {
-    @EnvironmentObject var downloadManager: BookDownloadManager
     @ObservedObject var viewModel: BookDetailViewModel
     var book: CalibreBook
     var lastUpdated: Date
@@ -361,7 +359,7 @@ struct BookFormatList: View {
                                 .font(.subheadline)
                                 .frame(minWidth: 48, alignment: .leading)
                             cacheFormatButton(book: book, format: format, formatInfo: formatInfo)
-                                .disabled(downloadManager.activeDownloads.filter( { $1.book.id == book.id && $1.format == format && ($1.isDownloading || $1.resumeData != nil) } ).count > 0)
+                                .disabled(viewModel.activeDownloads.filter( { $1.book.id == book.id && $1.format == format && ($1.isDownloading || $1.resumeData != nil) } ).count > 0)
                             
                             clearFormatButton(book: book, format: format, formatInfo: formatInfo)
                                 .disabled(!formatInfo.cached)
@@ -371,7 +369,7 @@ struct BookFormatList: View {
                         }
                         HStack {
                             Text(ByteCountFormatter.string(fromByteCount: Int64(formatInfo.serverSize), countStyle: .file))
-                            if let download = downloadManager.activeDownloads.filter( { $1.book.id == book.id && $1.format == format && ($1.isDownloading || $1.resumeData != nil) } ).first?.value {
+                            if let download = viewModel.activeDownloads.filter( { $1.book.id == book.id && $1.format == format && ($1.isDownloading || $1.resumeData != nil) } ).first?.value {
                                 ProgressView(value: download.progress)
                                     .progressViewStyle(LinearProgressViewStyle())
                                     .frame(maxWidth: 160)

--- a/YetAnotherEBookReader/Views/BookDetailView/BookDetailSubviews.swift
+++ b/YetAnotherEBookReader/Views/BookDetailView/BookDetailSubviews.swift
@@ -1,0 +1,479 @@
+import SwiftUI
+import KingfisherSwiftUI
+import RealmSwift
+
+struct BookCoverView: View {
+    @EnvironmentObject var modelData: ModelData
+    @EnvironmentObject var downloadManager: BookDownloadManager
+    @ObservedObject var viewModel: BookDetailViewModel
+    var book: CalibreBook
+    var lastUpdated: Date
+    
+    @Binding var presentingReadingSheet: Bool
+    @Binding var alertItem: AlertItem?
+
+    var body: some View {
+        ZStack {
+            KFImage(book.coverURL)
+                .placeholder {
+                    Text("Loading Cover ...")
+                }
+                .resizable()
+                .scaledToFit()
+            Button(action: {
+                guard downloadManager.activeDownloads.filter({ $1.isDownloading && $1.book.id == book.id }).isEmpty else { return }
+                viewModel.readBook(book: book)
+                if book.inShelf {
+                    presentingReadingSheet = true
+                }
+            }) {
+                if downloadManager.activeDownloads.filter({ $1.book.id == book.id && ($1.isDownloading || $1.resumeData != nil) }).isEmpty == false ||
+                    book.formats.filter({ $0.value.selected == true && $0.value.cached == false }).isEmpty == false {
+                    ProgressView()
+                        .progressViewStyle(CircularProgressViewStyle(tint: .gray))
+                        .scaleEffect(6, anchor: .center)
+                } else if book.inShelf,
+                          book.formats.allSatisfy({ $1.selected != true || $1.cached }) {
+                    Image(systemName: "book")
+                        .resizable()
+                        .frame(width: 160, height: 160)
+                        .foregroundColor(.gray)
+                } else {
+                    Image(systemName: "tray.and.arrow.down")
+                        .resizable()
+                        .frame(width: 160, height: 160)
+                        .foregroundColor(.gray)
+                }
+            }
+            .opacity(0.8)
+            .fullScreenCover(isPresented: $presentingReadingSheet) {
+                YabrEBookReader(
+                    book: book,
+                    readerInfo: modelData.prepareBookReading(book: book)
+                )
+            }
+        }
+        .frame(width: 300, height: 400)
+    }
+}
+
+struct BookMetadataSection: View {
+    @Environment(\.openURL) var openURL
+    @EnvironmentObject var modelData: ModelData
+    @ObservedObject var viewModel: BookDetailViewModel
+    var book: CalibreBook
+    var lastUpdated: Date
+    var isCompat: Bool
+    
+    @Binding var readingPositionHistoryViewPresenting: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                metadataIcon(systemName: "building.columns")
+                Text("\(book.library.name) - \(book.id) @ Server \(book.library.server.name)")
+            }
+            HStack {
+                metadataIcon(systemName: "face.smiling")
+                Text(book.ratingDescription)
+                if let ratingGRDescription = book.ratingGRDescription {
+                    Text(" (\(ratingGRDescription))")
+                }
+            }
+            HStack {
+                if book.authors.count <= 1 {
+                    metadataIcon(systemName: "person")
+                } else if book.authors.count == 2 {
+                    metadataIcon(systemName: "person.2")
+                } else {
+                    metadataIcon(systemName: "person.3")
+                }
+                Text(book.authorsDescription)
+            }
+            HStack {
+                metadataIcon(systemName: "house")
+                Text(book.publisher)
+            }
+            HStack {
+                metadataIcon(systemName: "calendar")
+                Text(book.pubDateByLocale)
+            }
+            HStack {
+                metadataIcon(systemName: "tray.2")
+                Text("\(book.seriesDescription) (\(book.seriesIndexDescription))")
+            }
+            
+            HStack {
+                metadataIcon(systemName: "tag")
+                Text(book.tagsDescription)
+            }
+            
+            HStack {
+                metadataIcon(systemName: "link")
+                
+                Button(action:{
+                    var url: URL? = nil
+                    defer {
+                        if let url = url {
+                            openURL(url)
+                        }
+                    }
+                    
+                    if let goodreadsId = book.identifiers["goodreads"] {
+                       url = URL(string: "https://www.goodreads.com/book/show/\(goodreadsId)")
+                    } else if var urlComponents = URLComponents(string: "https://www.goodreads.com/search") {
+                        urlComponents.queryItems = [URLQueryItem(name: "q", value: book.title + " " + book.authors.joined(separator: " "))]
+                        url = urlComponents.url
+                    }
+                }) {
+                    metadataLinkIcon("icon-goodreads", matched: book.identifiers["goodreads"] != nil)
+                }
+                
+                Button(action:{
+                    var url: URL? = nil
+                    defer {
+                        if let url = url {
+                            openURL(url)
+                        }
+                    }
+                    
+                    if let id = book.identifiers["amazon"] {
+                       url = URL(string: "http://www.amazon.com/dp/\(id)")
+                    } else if var urlComponents = URLComponents(string: "https://www.amazon.com/s") {
+                        urlComponents.queryItems = [URLQueryItem(name: "k", value: book.title + " " + book.authors.joined(separator: " "))]
+                        url = urlComponents.url
+                    }
+                }) {
+                    metadataLinkIcon("icon-amazon", matched: book.identifiers["amazon"] != nil)
+                }
+            }
+            
+            Group {
+                HStack {
+                    metadataIcon(systemName: "envelope.open")
+                    Text(book.lastModifiedByLocale)
+                }
+                
+                BookProgressSection(viewModel: viewModel, book: book, lastUpdated: lastUpdated, isCompat: isCompat, readingPositionHistoryViewPresenting: $readingPositionHistoryViewPresenting)
+                
+                HStack {
+                    metadataIcon(systemName: "books.vertical")
+                    let pluginGoodreadsSync = book.library.pluginGoodreadsSyncWithDefault
+                    if pluginGoodreadsSync.isEnabled, pluginGoodreadsSync.tagsColumnName.count > 0,
+                       let shelves = book.userMetadatas[pluginGoodreadsSync.tagsColumnName.trimmingCharacters(in: CharacterSet(["#"]))] as? [String],
+                       shelves.count > 0 {
+                        Text(shelves.joined(separator: ", "))
+                    } else {
+                        Text("Unspecified")
+                    }
+                }
+            }
+        }
+        .lineLimit(2)
+        .font(.subheadline)
+    }
+    
+    private func metadataIcon(systemName: String) -> some View {
+        Image(systemName: systemName)
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .frame(width: 36, height: 24, alignment: .center)
+    }
+    
+    private func metadataLinkIcon(_ name: String, matched: Bool = false) -> some View {
+        HStack(alignment: .top, spacing: -2) {
+            Image(name)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 20, height: 20)
+            if matched == false {
+                Image(systemName: "questionmark")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 8, height: 8)
+            }
+        }
+    }
+}
+
+struct BookProgressSection: View {
+    @EnvironmentObject var modelData: ModelData
+    @ObservedObject var viewModel: BookDetailViewModel
+    var book: CalibreBook
+    var lastUpdated: Date
+    var isCompat: Bool
+    
+    @Binding var readingPositionHistoryViewPresenting: Bool
+
+    var body: some View {
+        HStack {
+            Image(systemName: "text.book.closed")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 36, height: 24, alignment: .center)
+            
+            Button(action:{
+                viewModel.prepareReadingPositionHistory(book: book)
+                readingPositionHistoryViewPresenting = true
+            }) {
+                if let readDateGR = book.readDateGRByLocale {
+                    Image(systemName: "arrow.down.to.line")
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 20, height: 20)
+                    Text(readDateGR)
+                } else if let readProgressGR = book.readProgressGRDescription {
+                    Image(systemName: "hourglass")
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 20, height: 20)
+                    Text("\(readProgressGR)%")
+                } else if let position = book.readPos.getPosition(modelData.deviceName) ?? book.readPos.getDevices().first {
+                    Image(systemName: "book.circle")
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 20, height: 20)
+                    Text(String(format: "%.1f%%", position.lastProgress))
+                    Text("on")
+                    Text(position.id)
+                } else {
+                    Text("No Reading History")
+                }
+            }.disabled(book.readPos.isEmpty)
+        }.sheet(isPresented: $readingPositionHistoryViewPresenting, onDismiss: {
+            readingPositionHistoryViewPresenting = false
+        }, content: {
+            NavigationView {
+                ReadingPositionHistoryView(presenting: $readingPositionHistoryViewPresenting, library: book.library, bookId: book.id)
+                    .toolbar {
+                        ToolbarItem(placement: .cancellationAction, content: {
+                            Button(action: {
+                                readingPositionHistoryViewPresenting = false
+                            }) {
+                                Image(systemName: "xmark")
+                            }
+                        })
+                    }
+            }
+        })
+    }
+}
+
+struct BookConnectivitySection: View {
+    @EnvironmentObject var modelData: ModelData
+    var book: CalibreBook
+    var lastUpdated: Date
+    var isCompat: Bool
+    
+    @Binding var activityListViewPresenting: Bool
+    @Binding var alertItem: AlertItem?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if modelData.updatingMetadataStatus == "Success" {
+                HStack {
+                    metadataIcon(systemName: "checkmark.shield")
+                    Text("In Sync with Server")
+                }
+            } else if modelData.updatingMetadataStatus == "Local File" {
+                HStack {
+                    metadataIcon(systemName: "doc")
+                    Text("Local File")
+                }
+            } else if modelData.updatingMetadataStatus == "Deleted" {
+                HStack {
+                    metadataIcon(systemName: "xmark.shield")
+                    Text("Been Deleted on Server")
+                }
+            } else if modelData.updatingMetadataStatus == "Updating" {
+                HStack {
+                    metadataIcon(systemName: "arrow.clockwise")
+                    Text("Syncing with Server")
+                }
+            } else {
+                VStack(alignment: .trailing, spacing: 4) {
+                    Button(action:{
+                        alertItem = AlertItem(id: "Sync Error", msg: modelData.updatingMetadataStatus)
+                    }) {
+                        HStack {
+                            metadataIcon(systemName: "exclamationmark.shield")
+                            Text("Sync Error Encounted")
+                        }
+                    }
+                }
+            }
+            HStack {
+                metadataIcon(systemName: "scroll")
+                Button(action: {
+                    activityListViewPresenting = true
+                }) {
+                    Text("Activity Logs")
+                }.sheet(isPresented: $activityListViewPresenting, onDismiss: {
+                }, content: {
+                    NavigationView {
+                        ActivityList(presenting: $activityListViewPresenting, libraryId: book.library.id, bookId: book.id)
+                            .environmentObject(modelData)
+                            .environmentObject(modelData.downloadManager)
+                            .environmentObject(modelData.sessionManager)
+                            .environmentObject(modelData.fontsManager)
+                            .environment(\.realmConfiguration, modelData.realmConf ?? Realm.Configuration.defaultConfiguration)
+                    }
+                })
+            }
+        }
+    }
+    
+    private func metadataIcon(systemName: String) -> some View {
+        Image(systemName: systemName)
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .frame(width: 36, height: 24, alignment: .center)
+    }
+}
+
+struct BookFormatList: View {
+    @EnvironmentObject var modelData: ModelData
+    @EnvironmentObject var downloadManager: BookDownloadManager
+    @ObservedObject var viewModel: BookDetailViewModel
+    var book: CalibreBook
+    var lastUpdated: Date
+    var isCompat: Bool
+    
+    @Binding var presentingPreviewSheet: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ForEach(book.formats.sorted {
+                $0.key < $1.key
+            }.compactMap {
+                if let format = Format(rawValue: $0.key) {
+                    return (format, $0.value)
+                }
+                return nil
+            } as [(Format, FormatInfo)], id: \.0) { format, formatInfo in
+                HStack(alignment: .top, spacing: 4) {
+                    metadataFormatIcon(format.rawValue)
+                        .padding(EdgeInsets(top: 8, leading: 6, bottom: 8, trailing: 6))
+                    
+                    VStack(alignment: .leading, spacing: 2) {
+                        HStack(alignment: .bottom, spacing: 24) {
+                            Text(format.rawValue)
+                                .font(.subheadline)
+                                .frame(minWidth: 48, alignment: .leading)
+                            cacheFormatButton(book: book, format: format, formatInfo: formatInfo)
+                                .disabled(downloadManager.activeDownloads.filter( { $1.book.id == book.id && $1.format == format && ($1.isDownloading || $1.resumeData != nil) } ).count > 0)
+                            
+                            clearFormatButton(book: book, format: format, formatInfo: formatInfo)
+                                .disabled(!formatInfo.cached)
+                            
+                            previewFormatButton(book: book, format: format, formatInfo: formatInfo)
+                                .disabled(!formatInfo.cached)
+                        }
+                        HStack {
+                            Text(ByteCountFormatter.string(fromByteCount: Int64(formatInfo.serverSize), countStyle: .file))
+                            if let download = downloadManager.activeDownloads.filter( { $1.book.id == book.id && $1.format == format && ($1.isDownloading || $1.resumeData != nil) } ).first?.value {
+                                ProgressView(value: download.progress)
+                                    .progressViewStyle(LinearProgressViewStyle())
+                                    .frame(maxWidth: 160)
+                                
+                                Button(action: {
+                                    if download.isDownloading {
+                                        modelData.pauseDownloadFormat(book: book, format: format)
+                                    } else {
+                                        modelData.resumeDownloadFormat(book: book, format: format)
+                                    }
+                                }) {
+                                    Image(systemName: download.isDownloading ? "pause" : "play")
+                                }
+                                
+                                Button(action:{
+                                    modelData.cancelDownloadFormat(book: book, format: format)
+                                }) {
+                                    Image(systemName: "xmark")
+                                        .foregroundColor(.red)
+                                }
+                            } else if formatInfo.cached {
+                                Text(formatInfo.cacheUptoDate ? "Up to date" : "Server has update")
+                                Image(systemName: formatInfo.cacheUptoDate ? "hand.thumbsup" : "hand.thumbsdown")
+                                    .resizable()
+                                    .aspectRatio(contentMode: .fit)
+                                    .frame(width: 16, height: 16)
+                            } else {
+                                Text("Not cached")
+                            }
+                        }
+                        .font(.caption)
+                    }
+                }
+            }
+        }
+    }
+    
+    private func cacheFormatButton(book: CalibreBook, format: Format, formatInfo: FormatInfo) -> some View {
+        Button(action:{
+            viewModel.cacheFormat(book: book, format: format)
+        }) {
+            Image(systemName: "tray.and.arrow.down")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 24, height: 24)
+        }
+    }
+    
+    private func clearFormatButton(book: CalibreBook, format: Format, formatInfo: FormatInfo) -> some View {
+        Button(action:{
+            viewModel.clearFormat(book: book, format: format)
+        }) {
+            Image(systemName: "tray.and.arrow.up")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 24, height: 24)
+        }
+    }
+    
+    private func previewFormatButton(book: CalibreBook, format: Format, formatInfo: FormatInfo) -> some View {
+        Button(action: {
+            if viewModel.previewAction(book: book, format: format, formatInfo: formatInfo) {
+                presentingPreviewSheet = true
+            }
+        }) {
+            Image(systemName: "doc.text.magnifyingglass")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 24, height: 24)
+        }
+        .sheet(isPresented: $presentingPreviewSheet, onDismiss: {
+            modelData.readerInfo = modelData.prepareBookReading(book: book)
+        }) {
+            BookPreviewView(viewModel: viewModel.previewViewModel)
+        }
+    }
+    
+    private func metadataFormatIcon(_ name: String) -> some View {
+        Image(name)
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .frame(width: 24, height: 24)
+    }
+}
+
+struct BookCountPagesCorner: View {
+    var book: CalibreBook
+    var lastUpdated: Date
+    var countPage: CalibreCountPagesPrefs.LibraryConfig
+    var isCompat: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Count Pages Info Corner")
+            HStack {
+                Text("Pages \(book.userMetadataNumberAsIntDescription(column: countPage.pageCountCN) ?? "not set")")
+                Text("/").padding([.leading, .trailing], 16)
+                Text("Words \(book.userMetadataNumberAsIntDescription(column: countPage.wordCountCN) ?? "not set")")
+            }.font(.subheadline)
+            HStack {
+                Text("Readability \(book.userMetadataNumberAsFloatDescription(column: countPage.fleschReadingEaseCN) ?? "not set") / \(book.userMetadataNumberAsFloatDescription(column: countPage.fleschKincaidGradeCN) ?? "not set") / \(book.userMetadataNumberAsFloatDescription(column: countPage.gunningFogIndexCN) ?? "not set")")
+            }.font(.subheadline)
+        }
+    }
+}

--- a/YetAnotherEBookReader/Views/BookDetailView/BookDetailSubviews.swift
+++ b/YetAnotherEBookReader/Views/BookDetailView/BookDetailSubviews.swift
@@ -305,12 +305,10 @@ struct BookConnectivitySection: View {
                 }, content: {
                     NavigationView {
                         if let modelData = viewModel.sharedModelData {
-                            ActivityList(presenting: $viewModel.activityListViewPresenting, libraryId: book.library.id, bookId: book.id)
-                                .environmentObject(modelData)
-                                .environmentObject(modelData.downloadManager)
-                                .environmentObject(modelData.sessionManager)
-                                .environmentObject(modelData.fontsManager)
-                                .environment(\.realmConfiguration, modelData.realmConf ?? Realm.Configuration.defaultConfiguration)
+                            ActivityList(
+                                viewModel: ActivityListViewModel(modelData: modelData, libraryId: book.library.id, bookId: book.id),
+                                presenting: $viewModel.activityListViewPresenting
+                            )
                         }
                     }
                 })

--- a/YetAnotherEBookReader/Views/BookDetailView/BookDetailView.swift
+++ b/YetAnotherEBookReader/Views/BookDetailView/BookDetailView.swift
@@ -14,6 +14,7 @@ import KingfisherSwiftUI
 
 struct BookDetailView: View {
     @EnvironmentObject var modelData: ModelData
+    @EnvironmentObject var downloadManager: BookDownloadManager
     @Environment(\.horizontalSizeClass) var sizeClass
     @Environment(\.openURL) var openURL
     
@@ -27,10 +28,7 @@ struct BookDetailView: View {
     
     var defaultLog = Logger()
     
-    @State private var alertItem: AlertItem?
 
-    @State private var updater = 0
-    
     @State private var presentingReadingSheet = false {
         willSet { if newValue { modelData.presentingStack.append($presentingReadingSheet) } }
         didSet { if oldValue { _ = modelData.presentingStack.popLast() } }
@@ -57,26 +55,18 @@ struct BookDetailView: View {
         
         ScrollView {
             Text(book.title)
-            if let book = modelData.convert(bookRealm: book) {
-                viewContent(book: book, isCompat: sizeClass == .compact)
+            if let calibreBook = modelData.convert(bookRealm: book) {
+                viewContent(book: calibreBook, isCompat: sizeClass == .compact)
                     .onAppear() {
-                        //                        modelData.calibreServerService.getMetadata(oldbook: book, completion: initStates(book:))
-                        Task {
-                            await modelData.getBooksMetadata(
-                                request: .init(
-                                    library: book.library,
-                                    books: [book.id],
-                                    getAnnotations: true
-                                )
-                            )
-                        }
+                        _viewModel.setup(modelData: modelData, book: book, calibreBook: calibreBook)
+                        _viewModel.fetchMetadata(book: calibreBook)
                     }
                     .padding(EdgeInsets(top: 5, leading: 10, bottom: 5, trailing: 10))
                     .navigationTitle(Text(book.title))
                     .toolbar {
-                        toolbarContent(book: book)
+                        toolbarContent(book: calibreBook)
                     }
-                    .alert(item: $alertItem) { item in
+                    .alert(item: $_viewModel.alertItem) { item in
                         return Alert(title: Text(item.id), message: Text(item.msg ?? item.id))
                     }
             } else {
@@ -97,35 +87,40 @@ struct BookDetailView: View {
             
             if isCompat {
                 VStack(alignment: .center, spacing: 16) {
-                    coverViewContent(book: book)
+                    BookCoverView(viewModel: _viewModel, book: book, lastUpdated: book.lastUpdated, presentingReadingSheet: $presentingReadingSheet, alertItem: $_viewModel.alertItem)
                     
-                    metadataViewContent(book: book, isCompat: isCompat)
+                    BookMetadataSection(viewModel: _viewModel, book: book, lastUpdated: book.lastUpdated, isCompat: isCompat, readingPositionHistoryViewPresenting: $readingPositionHistoryViewPresenting)
                         .frame(minWidth: 300, maxWidth: 300, alignment: .leading)
-                    connectivityViewContent(book: book, isCompat: isCompat)
+                    
+                    BookConnectivitySection(book: book, lastUpdated: book.lastUpdated, isCompat: isCompat, activityListViewPresenting: $activityListViewPresenting, alertItem: $_viewModel.alertItem)
                         .frame(minWidth: 300, maxWidth: 300, alignment: .leading)
-                    bookFormatViewContent(book: book, isCompat: isCompat)
+                    
+                    BookFormatList(viewModel: _viewModel, book: book, lastUpdated: book.lastUpdated, isCompat: isCompat, presentingPreviewSheet: $presentingPreviewSheet)
                         .frame(minWidth: 300, maxWidth: 300, alignment: .leading)
                     
                     let countPage = book.library.pluginCountPagesWithDefault
                     if countPage.isEnabled {
-                        countPagesCorner(book: book, countPage: countPage, isCompat: isCompat)
+                        BookCountPagesCorner(book: book, lastUpdated: book.lastUpdated, countPage: countPage, isCompat: isCompat)
                             .frame(minWidth: 300, maxWidth: 300, alignment: .leading)
                     }
                 }
             } else {
                 HStack(alignment: .top, spacing: 32) {
-                    coverViewContent(book: book)
+                    BookCoverView(viewModel: _viewModel, book: book, lastUpdated: book.lastUpdated, presentingReadingSheet: $presentingReadingSheet, alertItem: $_viewModel.alertItem)
+                    
                     VStack(alignment: .leading, spacing: 16) {
-                        metadataViewContent(book: book, isCompat: isCompat)
+                        BookMetadataSection(viewModel: _viewModel, book: book, lastUpdated: book.lastUpdated, isCompat: isCompat, readingPositionHistoryViewPresenting: $readingPositionHistoryViewPresenting)
                             .frame(minWidth: 300, maxWidth: 300, alignment: .leading)
-                        connectivityViewContent(book: book, isCompat: isCompat)
+                        
+                        BookConnectivitySection(book: book, lastUpdated: book.lastUpdated, isCompat: isCompat, activityListViewPresenting: $activityListViewPresenting, alertItem: $_viewModel.alertItem)
                             .frame(minWidth: 300, maxWidth: 300, alignment: .leading)
-                        bookFormatViewContent(book: book, isCompat: isCompat)
+                        
+                        BookFormatList(viewModel: _viewModel, book: book, lastUpdated: book.lastUpdated, isCompat: isCompat, presentingPreviewSheet: $presentingPreviewSheet)
                             .frame(minWidth: 300, maxWidth: 300, alignment: .leading)
                         
                         let countPage = book.library.pluginCountPagesWithDefault
                         if countPage.isEnabled {
-                            countPagesCorner(book: book, countPage: countPage, isCompat: isCompat)
+                            BookCountPagesCorner(book: book, lastUpdated: book.lastUpdated, countPage: countPage, isCompat: isCompat)
                                 .frame(minWidth: 300, maxWidth: 300, alignment: .leading)
                         }
                     }
@@ -144,472 +139,6 @@ struct BookDetailView: View {
             )
             .frame(maxWidth: isCompat ? 400 : 600, minHeight: 400, maxHeight: 400, alignment: .center)
             
-        }   //VStack
-        //.fixedSize()
-    }
-    
-    @ViewBuilder
-    private func coverViewContent(book: CalibreBook) -> some View {
-        ZStack {
-            KFImage(book.coverURL)
-                .placeholder {
-                    Text("Loading Cover ...")
-                }
-                .resizable()
-                .scaledToFit()
-            Button(action: {
-                guard modelData.downloadManager.activeDownloads.filter( {$1.isDownloading && $1.book.id == book.id} ).isEmpty else { return }
-                
-                if book.inShelf {
-                    modelData.readerInfo = modelData.prepareBookReading(book: book)
-                    presentingReadingSheet = true
-                } else {
-                    //TODO prompt for formats
-                    if let downloadFormat = modelData.getPreferredFormat(for: book) {
-                        modelData.addToShelf(book: book, formats: [downloadFormat])
-                    } else {
-                        alertItem = AlertItem(id: "Error Download Book", msg: "Sorry, there's no supported book format")
-                    }
-                }
-            }) {
-                if modelData.downloadManager.activeDownloads.filter( { $1.book.id == book.id && ($1.isDownloading || $1.resumeData != nil) } ).isEmpty == false ||
-                    book.formats.filter({ $0.value.selected == true && $0.value.cached == false }).isEmpty == false
-                {
-                    ProgressView()
-                        .progressViewStyle(CircularProgressViewStyle(tint: .gray))
-                        .scaleEffect(6, anchor: .center)
-                } else if book.inShelf,
-                          book.formats.allSatisfy({ $1.selected != true || $1.cached }) {
-                    Image(systemName: "book")
-                        .resizable()
-                        .frame(width: 160, height: 160)
-                        .foregroundColor(.gray)
-                } else {
-                    Image(systemName: "tray.and.arrow.down")
-                        .resizable()
-                        .frame(width: 160, height: 160)
-                        .foregroundColor(.gray)
-                }
-                
-            }
-            .opacity(0.8)
-            .fullScreenCover(isPresented: $presentingReadingSheet) {
-                YabrEBookReader(
-                    book: book,
-                    readerInfo: modelData.prepareBookReading(book: book)
-                )
-            }
-        }
-        .frame(width: 300, height: 400)
-    }
-    
-    @ViewBuilder
-    private func metadataViewContent(book: CalibreBook, isCompat: Bool) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack {
-                metadataIcon(systemName: "building.columns")
-                Text("\(book.library.name) - \(book.id) @ Server \(book.library.server.name)")
-            }
-            HStack {
-                metadataIcon(systemName: "face.smiling")
-                Text(book.ratingDescription)
-                if let ratingGRDescription = book.ratingGRDescription {
-                    Text(" (\(ratingGRDescription))")
-                }
-            }
-            HStack {
-                if book.authors.count <= 1 {
-                    metadataIcon(systemName: "person")
-                } else if book.authors.count == 2 {
-                    metadataIcon(systemName: "person.2")
-                } else {
-                    metadataIcon(systemName: "person.3")
-                }
-                Text(book.authorsDescription)
-            }
-            HStack {
-                metadataIcon(systemName: "house")
-                Text(book.publisher)
-            }
-            HStack {
-                metadataIcon(systemName: "calendar")
-                Text(book.pubDateByLocale)
-            }
-            HStack {
-                metadataIcon(systemName: "tray.2")
-                Text("\(book.seriesDescription) (\(book.seriesIndexDescription))")
-            }
-            
-            HStack {
-                metadataIcon(systemName: "tag")
-                Text(book.tagsDescription)
-            }
-            
-            HStack {
-                metadataIcon(systemName: "link")
-                
-                Button(action:{
-                    var url: URL? = nil
-                    defer {
-                        if let url = url {
-                            openURL(url)
-                        }
-                    }
-                    
-                    if let goodreadsId = book.identifiers["goodreads"] {
-                       url = URL(string: "https://www.goodreads.com/book/show/\(goodreadsId)")
-                    } else if var urlComponents = URLComponents(string: "https://www.goodreads.com/search") {
-                        urlComponents.queryItems = [URLQueryItem(name: "q", value: book.title + " " + book.authors.joined(separator: " "))]
-                        url = urlComponents.url
-                    }
-                }) {
-                    metadataLinkIcon("icon-goodreads", matched: book.identifiers["goodreads"] != nil)
-                }
-                
-                Button(action:{
-                    var url: URL? = nil
-                    defer {
-                        if let url = url {
-                            openURL(url)
-                        }
-                    }
-                    
-                    if let id = book.identifiers["amazon"] {
-                       url = URL(string: "http://www.amazon.com/dp/\(id)")
-                    } else if var urlComponents = URLComponents(string: "https://www.amazon.com/s") {
-                        urlComponents.queryItems = [URLQueryItem(name: "k", value: book.title + " " + book.authors.joined(separator: " "))]
-                        url = urlComponents.url
-                    }
-                }) {
-                    metadataLinkIcon("icon-amazon", matched: book.identifiers["amazon"] != nil)
-                }
-                
-            }
-            
-            Group {     // lastModified readDate(GR) ShelfName
-                HStack {
-                    metadataIcon(systemName: "envelope.open")
-                    Text(book.lastModifiedByLocale)
-                }
-                
-                progressView(book: book, isCompat: isCompat)
-                
-                HStack {
-                    metadataIcon(systemName: "books.vertical")
-                    let pluginGoodreadsSync = book.library.pluginGoodreadsSyncWithDefault
-                    if pluginGoodreadsSync.isEnabled, pluginGoodreadsSync.tagsColumnName.count > 0,
-                       let shelves = book.userMetadatas[pluginGoodreadsSync.tagsColumnName.trimmingCharacters(in: CharacterSet(["#"]))] as? [String],
-                       shelves.count > 0 {
-                        Text(shelves.joined(separator: ", "))
-                    } else {
-                        Text("Unspecified")
-                    }
-                }
-            }
-        }
-        .lineLimit(2)
-        .font(.subheadline)
-        
-    }
-    
-    @ViewBuilder
-    private func progressView(book: CalibreBook, isCompat: Bool) -> some View {
-        HStack {
-            metadataIcon(systemName: "text.book.closed")
-            
-            Button(action:{
-                if _viewModel.listVM == nil {
-                    _viewModel.listVM = ReadingPositionListViewModel(
-                        modelData: modelData, book: book, positions: book.readPos.getDevices().sorted(by: { $0.epoch > $1.epoch })
-                    )
-                } else {
-                    _viewModel.listVM.book = book
-                    _viewModel.listVM.positions = book.readPos.getDevices().sorted(by: { $0.epoch > $1.epoch })
-                }
-                readingPositionHistoryViewPresenting = true
-            }) {
-                if let readDateGR = book.readDateGRByLocale {
-                    Image(systemName: "arrow.down.to.line")
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(width: 20, height: 20)
-                    Text(readDateGR)
-                } else if let readProgressGR = book.readProgressGRDescription {
-                    Image(systemName: "hourglass")
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(width: 20, height: 20)
-                    Text("\(readProgressGR)%")
-                } else if let position = book.readPos.getPosition(modelData.deviceName) ?? book.readPos.getDevices().first {
-                    Image(systemName: "book.circle")
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(width: 20, height: 20)
-                    Text(String(format: "%.1f%%", position.lastProgress))
-                    Text("on")
-                    Text(position.id)
-                } else {
-                    Text("No Reading History")
-                }
-            }.disabled(book.readPos.isEmpty)
-        }.sheet(isPresented: $readingPositionHistoryViewPresenting, onDismiss: {
-            readingPositionHistoryViewPresenting = false
-        }, content: {
-            NavigationView {
-                ReadingPositionHistoryView(presenting: $readingPositionHistoryViewPresenting, library: book.library, bookId: book.id)
-                    .toolbar {
-                        ToolbarItem(placement: .cancellationAction, content: {
-                            Button(action: {
-                                readingPositionHistoryViewPresenting = false
-                            }) {
-                                Image(systemName: "xmark")
-                            }
-                        })
-                    }
-            }
-        })
-    }
-    
-    @ViewBuilder
-    private func connectivityViewContent(book: CalibreBook, isCompat: Bool) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            if modelData.updatingMetadataStatus == "Success" {
-                HStack {
-                    metadataIcon(systemName: "checkmark.shield")
-                    Text("In Sync with Server")
-                }
-            } else if modelData.updatingMetadataStatus == "Local File" {
-                HStack {
-                    metadataIcon(systemName: "doc")
-                    Text("Local File")
-                }
-            } else if modelData.updatingMetadataStatus == "Deleted" {
-                HStack {
-                    metadataIcon(systemName: "xmark.shield")
-                    Text("Been Deleted on Server")
-                }
-            } else if modelData.updatingMetadataStatus == "Updating" {
-                HStack {
-                    metadataIcon(systemName: "arrow.clockwise")
-                    Text("Syncing with Server")
-                }
-            } else {
-                VStack(alignment: .trailing, spacing: 4) {
-                    Button(action:{
-                        alertItem = AlertItem(id: "Sync Error", msg: modelData.updatingMetadataStatus)
-                    }) {
-                        HStack {
-                            metadataIcon(systemName: "exclamationmark.shield")
-                            Text("Sync Error Encounted")
-                        }
-                    }
-                    
-                }
-            }
-            HStack {
-                metadataIcon(systemName: "scroll")
-                Button(action: {
-                    activityListViewPresenting = true
-                }) {
-                    Text("Activity Logs")
-                }.sheet(isPresented: $activityListViewPresenting, onDismiss: {
-                    
-                }, content: {
-                    NavigationView {
-                        ActivityList(presenting: $activityListViewPresenting, libraryId: book.library.id, bookId: book.id)
-                            .environmentObject(modelData)
-                            .environmentObject(modelData.downloadManager)
-                            .environmentObject(modelData.sessionManager)
-                            .environmentObject(modelData.fontsManager)
-                            .environment(\.realmConfiguration, modelData.realmConf ?? Realm.Configuration.defaultConfiguration)
-                    }
-                })
-            }
-            
-        }
-
-    }
-    
-    @ViewBuilder
-    private func metadataIcon(systemName: String) -> some View {
-        Image(systemName: systemName)
-            .resizable()
-            .aspectRatio(contentMode: .fit)
-            .frame(width: 36, height: 24, alignment: .center)
-    }
-    
-    @ViewBuilder
-    private func metadataLinkIcon(_ name: String, matched: Bool = false) -> some View {
-        HStack(alignment: .top, spacing: -2) {
-            Image(name)
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(width: 20, height: 20)
-            if matched == false {
-                Image(systemName: "questionmark")
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: 8, height: 8)
-            }
-        }
-    }
-    
-    @ViewBuilder
-    private func metadataFormatIcon(_ name: String) -> some View {
-        Image(name)
-            .resizable()
-            .aspectRatio(contentMode: .fit)
-            .frame(width: 24, height: 24)
-    }
-    
-    @ViewBuilder
-    private func countPagesCorner(book: CalibreBook, countPage: CalibreCountPagesPrefs.LibraryConfig, isCompat: Bool) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Count Pages Info Corner")
-            HStack {
-                Text("Pages \(book.userMetadataNumberAsIntDescription(column: countPage.pageCountCN) ?? "not set")")
-                Text("/").padding([.leading, .trailing], 16)
-                Text("Words \(book.userMetadataNumberAsIntDescription(column: countPage.wordCountCN) ?? "not set")")
-                
-            }.font(.subheadline)
-            HStack {
-                Text("Readability \(book.userMetadataNumberAsFloatDescription(column: countPage.fleschReadingEaseCN) ?? "not set") / \(book.userMetadataNumberAsFloatDescription(column: countPage.fleschKincaidGradeCN) ?? "not set") / \(book.userMetadataNumberAsFloatDescription(column: countPage.gunningFogIndexCN) ?? "not set")")
-            }.font(.subheadline)
-        }
-    }
-    
-    @ViewBuilder
-    private func bookFormatViewContent(book: CalibreBook, isCompat: Bool) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            ForEach(book.formats.sorted {
-                $0.key < $1.key
-            }.compactMap {
-                if let format = Format(rawValue: $0.key) {
-                    return (format, $0.value)
-                }
-                return nil
-            } as [(Format, FormatInfo)], id: \.0) { format, formatInfo in
-                HStack(alignment: .top, spacing: 4) {
-                    metadataFormatIcon(
-                        format.rawValue
-                    )
-                    .padding(EdgeInsets(top: 8, leading: 6, bottom: 8, trailing: 6))
-                    
-                    VStack(alignment: .leading, spacing: 2) {
-                        HStack(alignment: .bottom, spacing: 24) {
-                            Text(format.rawValue)
-                                .font(.subheadline)
-                                .frame(minWidth: 48, alignment: .leading)
-                            cacheFormatButton(
-                                book: book,
-                                format: format,
-                                formatInfo: formatInfo
-                            ).disabled(modelData.downloadManager.activeDownloads.filter( { $1.book.id == book.id && $1.format == format && ($1.isDownloading || $1.resumeData != nil) } ).count > 0)
-                            
-                            clearFormatButton(
-                                book: book,
-                                format: format,
-                                formatInfo: formatInfo
-                            ).disabled(!formatInfo.cached)
-                            
-                            previewFormatButton(
-                                book: book,
-                                format: format,
-                                formatInfo: formatInfo
-                            ).disabled(!formatInfo.cached)
-                        }
-                        HStack {
-                            Text(
-                                ByteCountFormatter.string(
-                                    fromByteCount: Int64(formatInfo.serverSize),
-                                    countStyle: .file
-                                )
-                            )
-                            if let download = modelData.downloadManager.activeDownloads.filter( { $1.book.id == book.id && $1.format == format && ($1.isDownloading || $1.resumeData != nil) } ).first?.value {
-                                ProgressView(value: download.progress)
-                                    .progressViewStyle(LinearProgressViewStyle())
-                                    .frame(maxWidth: 160)
-                                
-                                Button(action: {
-                                    if download.isDownloading {
-                                        modelData.pauseDownloadFormat(book: book, format: format)
-                                    } else {
-                                        modelData.resumeDownloadFormat(book: book, format: format)
-                                    }
-                                    
-                                }) {
-                                    Image(systemName: download.isDownloading ? "pause" : "play")
-                                }
-                                
-                                //cancel download
-                                Button(action:{
-                                    modelData.cancelDownloadFormat(book: book, format: format)
-                                }) {
-                                    Image(systemName: "xmark")
-                                        .foregroundColor(.red)
-                                }
-                            } else if formatInfo.cached {
-                                Text(formatInfo.cacheUptoDate ? "Up to date" : "Server has update")
-                                Image(systemName: formatInfo.cacheUptoDate ? "hand.thumbsup" : "hand.thumbsdown")
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fit)
-                                    .frame(width: 16, height: 16)
-                            } else {
-                                Text("Not cached")
-                            }
-                        }
-                        .font(.caption)
-                    }
-                    
-                }
-            }
-        }
-    }
-    
-    private func cacheFormatButton(book: CalibreBook, format: Format, formatInfo: FormatInfo) -> some View {
-        Button(action:{
-            if book.inShelf {
-                modelData.startDownloadFormat(
-                    book: book,
-                    format: format,
-                    overwrite: true
-                )
-            } else {
-                modelData.addToShelf(book: book, formats: [format])
-            }
-        }) {
-            Image(systemName: "tray.and.arrow.down")
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(width: 24, height: 24)
-        }
-    }
-    
-    private func clearFormatButton(book: CalibreBook, format: Format, formatInfo: FormatInfo) -> some View {
-        Button(action:{
-            modelData.clearCache(book: book, format: format)
-        }) {
-            Image(systemName: "tray.and.arrow.up")
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(width: 24, height: 24)
-        }
-    }
-    
-    private func previewFormatButton(book: CalibreBook, format: Format, formatInfo: FormatInfo) -> some View {
-        Button(action: {
-            guard let reader = modelData.formatReaderMap[format]?.first else { return }
-            previewAction(book: book, format: format, formatInfo: formatInfo, reader: reader)
-        }) {
-            Image(systemName: "doc.text.magnifyingglass")
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(width: 24, height: 24)
-        }
-        .sheet(isPresented: $presentingPreviewSheet, onDismiss: {
-            modelData.readerInfo = modelData.prepareBookReading(book: book)
-        }) {
-            BookPreviewView(viewModel: previewViewModel)
         }
     }
     
@@ -617,23 +146,7 @@ struct BookDetailView: View {
     private func toolbarContent(book: CalibreBook) -> some ToolbarContent {
         ToolbarItem(placement: .cancellationAction) {
             Button(action: {
-                if modelData.updatingMetadata {
-                    //TODO cancel
-                } else {
-                    if let coverUrl = book.coverURL {
-                        modelData.kfImageCache.removeImage(forKey: coverUrl.absoluteString)
-                    }
-//                    modelData.calibreServerService.getMetadata(oldbook: book, completion: initStates(book:))
-                    Task {
-                        await modelData.getBooksMetadata(
-                            request: .init(
-                                library: book.library,
-                                books: [book.id],
-                                getAnnotations: true
-                            )
-                        )
-                    }
-                }
+                _viewModel.refresh(book: book)
             }) {
                 if modelData.updatingMetadata {
                     Image(systemName: "xmark")
@@ -645,19 +158,9 @@ struct BookDetailView: View {
         
         ToolbarItem(placement: .confirmationAction) {
             Button(action: {
-                if book.inShelf {
-                    modelData.clearCache(inShelfId: book.inShelfId)
-                } else if modelData.downloadManager.activeDownloads.filter( {$1.isDownloading && $1.book.id == book.id} ).isEmpty {
-                    //TODO prompt for formats
-                    if let downloadFormat = modelData.getPreferredFormat(for: book) {
-                        modelData.addToShelf(book: book, formats: [downloadFormat])
-                    } else {
-                        alertItem = AlertItem(id: "Error Download Book", msg: "Sorry, there's no supported book format")
-                    }
-                }
-                updater += 1
+                _viewModel.downloadOrClearCache(book: book)
             }) {
-                if let download = modelData.downloadManager.activeDownloads.filter( {$1.isDownloading && $1.book.id == book.id} ).first {
+                if let download = downloadManager.activeDownloads.filter( {$1.isDownloading && $1.book.id == book.id} ).first {
                     ProgressView()
                         .progressViewStyle(CircularProgressViewStyle())
                 } else if book.inShelf {
@@ -680,85 +183,6 @@ struct BookDetailView: View {
         }
     }
     
-    func initStates(book: CalibreBook) {
-        if _viewModel.listVM == nil {
-            _viewModel.listVM = ReadingPositionListViewModel(
-                modelData: modelData, book: book, positions: book.readPos.getDevices().sorted(by: { $0.epoch > $1.epoch })
-            )
-        } else {
-            _viewModel.listVM.book = book
-            _viewModel.listVM.positions = book.readPos.getDevices().sorted(by: { $0.epoch > $1.epoch })
-        }
-        
-//        modelData.calibreServerService.getAnnotations(
-//            book: book,
-//            formats: book.formats.keys.compactMap { Format(rawValue: $0) }
-//        )
-    }
-    
-    func previewAction(book: CalibreBook, format: Format, formatInfo: FormatInfo, reader: ReaderType) {
-        guard let bookFileUrl = getSavedUrl(book: book, format: format)
-        else {
-            alertItem = AlertItem(id: "Cannot locate book file", msg: "Please re-download \(format.rawValue)")
-            return
-        }
-        
-        let readPosition = book.readPos.createInitial(deviceName: modelData.deviceName, reader: reader)
-        
-        modelData.prepareBookReading(
-            url: bookFileUrl,
-            format: format,
-            readerType: reader,
-            position: readPosition
-        )
-        
-        previewViewModel.modelData = modelData
-        previewViewModel.book = book
-        previewViewModel.url = bookFileUrl
-        previewViewModel.format = format
-        previewViewModel.reader = reader
-        previewViewModel.toc = "Initializing"
-        
-        modelData.calibreServerService.getBookManifest(book: book, format: format) { data in
-            guard let data = data else { return }
-            self.parseManifestToTOC(json: data)
-        }
-        
-        presentingPreviewSheet = true
-    }
-    
-    func parseManifestToTOC(json: Data) {
-        previewViewModel.toc = "Without TOC"
-        
-        guard let root = try? JSONSerialization.jsonObject(with: json, options: []) as? NSDictionary else {
-            #if DEBUG
-            previewViewModel.toc = String(data: json, encoding: .utf8) ?? "String Decoding Failure"
-            #endif
-            return
-        }
-        
-        guard let tocNode = root["toc"] as? NSDictionary else {
-            #if DEBUG
-            previewViewModel.toc = String(data: json, encoding: .utf8) ?? "String Decoding Failure"
-            #endif
-            
-            if let jobStatus = root["job_status"] as? String, jobStatus == "waiting" || jobStatus == "running" {
-                previewViewModel.toc = "Generating TOC, Please try again later"
-            }
-            return
-        }
-        
-        guard let childrenNode = tocNode["children"] as? NSArray else {
-            return
-        }
-        
-        let tocString = childrenNode.reduce(into: String()) { result, childNode in
-            result = result + ((childNode as! NSDictionary)["title"] as! String) + "\n"
-        }
-        
-        previewViewModel.toc = tocString
-    }
-    
     func handleBookDeleted() {
 //        modelData.libraryInfo.deleteBook(book: book)
         //TODO
@@ -775,12 +199,6 @@ struct BookDetailView: View {
     }
 }
 
-extension BookDetailView : AlertDelegate {
-    func alert(alertItem: AlertItem) {
-        self.alertItem = alertItem
-    }
-}
-
 extension BookDetailView {
     enum Mode: String, CaseIterable, Identifiable {
         case SHELF
@@ -789,14 +207,3 @@ extension BookDetailView {
         var id: String { self.rawValue }
     }
 }
-/*
-@available(macCatalyst 14.0, *)
-struct BookDetailViewRealm_Previews: PreviewProvider {
-    static var modelData = ModelData(mock: true)
-     
-    static var previews: some View {
-        BookDetailViewRealm(viewMode: .LIBRARY)
-            .environmentObject(modelData)
-    }
-}
-*/

--- a/YetAnotherEBookReader/Views/BookDetailView/BookDetailView.swift
+++ b/YetAnotherEBookReader/Views/BookDetailView/BookDetailView.swift
@@ -34,7 +34,7 @@ struct BookDetailView: View {
         
         ScrollView {
             Text(book.title)
-            if let calibreBook = _viewModel.convert(bookRealm: book) {
+            if let calibreBook = modelData.convert(bookRealm: book) {
                 viewContent(book: calibreBook, isCompat: sizeClass == .compact)
                     .onAppear() {
                         _viewModel.setup(modelData: modelData, book: book, calibreBook: calibreBook)

--- a/YetAnotherEBookReader/Views/BookDetailView/BookDetailView.swift
+++ b/YetAnotherEBookReader/Views/BookDetailView/BookDetailView.swift
@@ -13,7 +13,6 @@ import RealmSwift
 import KingfisherSwiftUI
 
 struct BookDetailView: View {
-    @EnvironmentObject var modelData: ModelData
     @Environment(\.horizontalSizeClass) var sizeClass
     @Environment(\.openURL) var openURL
     
@@ -34,10 +33,10 @@ struct BookDetailView: View {
         
         ScrollView {
             Text(book.title)
-            if let calibreBook = modelData.convert(bookRealm: book) {
+            if let calibreBook = _viewModel.convert(bookRealm: book) {
                 viewContent(book: calibreBook, isCompat: sizeClass == .compact)
                     .onAppear() {
-                        _viewModel.setup(modelData: modelData, book: book, calibreBook: calibreBook)
+                        _viewModel.setup(book: book, calibreBook: calibreBook)
                         _viewModel.fetchMetadata(book: calibreBook)
                     }
                     .padding(EdgeInsets(top: 5, leading: 10, bottom: 5, trailing: 10))

--- a/YetAnotherEBookReader/Views/BookDetailView/BookDetailView.swift
+++ b/YetAnotherEBookReader/Views/BookDetailView/BookDetailView.swift
@@ -28,26 +28,6 @@ struct BookDetailView: View {
     var defaultLog = Logger()
     
 
-    @State private var presentingReadingSheet = false {
-        willSet { if newValue { _viewModel.pushPresenting($presentingReadingSheet) } }
-        didSet { if oldValue { _viewModel.popPresenting() } }
-    }
-    
-    @State private var presentingPreviewSheet = false {
-        willSet { if newValue { _viewModel.pushPresenting($presentingPreviewSheet) } }
-        didSet { if oldValue { _viewModel.popPresenting() } }
-    }
-    
-    @State private var activityListViewPresenting = false {
-        willSet { if newValue { _viewModel.pushPresenting($activityListViewPresenting) } }
-        didSet { if oldValue { _viewModel.popPresenting() } }
-    }
-
-    @State private var readingPositionHistoryViewPresenting = false {
-        willSet { if newValue { _viewModel.pushPresenting($readingPositionHistoryViewPresenting) } }
-        didSet { if oldValue { _viewModel.popPresenting() } }
-    }
-    
     @StateObject private var _viewModel = BookDetailViewModel()
     
     var body: some View {
@@ -86,15 +66,15 @@ struct BookDetailView: View {
             
             if isCompat {
                 VStack(alignment: .center, spacing: 16) {
-                    BookCoverView(viewModel: _viewModel, book: book, lastUpdated: book.lastUpdated, presentingReadingSheet: $presentingReadingSheet, alertItem: $_viewModel.alertItem)
+                    BookCoverView(viewModel: _viewModel, book: book, lastUpdated: book.lastUpdated, alertItem: $_viewModel.alertItem)
                     
-                    BookMetadataSection(viewModel: _viewModel, book: book, lastUpdated: book.lastUpdated, isCompat: isCompat, readingPositionHistoryViewPresenting: $readingPositionHistoryViewPresenting)
+                    BookMetadataSection(viewModel: _viewModel, book: book, lastUpdated: book.lastUpdated, isCompat: isCompat)
                         .frame(minWidth: 300, maxWidth: 300, alignment: .leading)
                     
-                    BookConnectivitySection(viewModel: _viewModel, book: book, lastUpdated: book.lastUpdated, isCompat: isCompat, activityListViewPresenting: $activityListViewPresenting, alertItem: $_viewModel.alertItem)
+                    BookConnectivitySection(viewModel: _viewModel, book: book, lastUpdated: book.lastUpdated, isCompat: isCompat, alertItem: $_viewModel.alertItem)
                         .frame(minWidth: 300, maxWidth: 300, alignment: .leading)
                     
-                    BookFormatList(viewModel: _viewModel, book: book, lastUpdated: book.lastUpdated, isCompat: isCompat, presentingPreviewSheet: $presentingPreviewSheet)
+                    BookFormatList(viewModel: _viewModel, book: book, lastUpdated: book.lastUpdated, isCompat: isCompat)
                         .frame(minWidth: 300, maxWidth: 300, alignment: .leading)
                     
                     let countPage = book.library.pluginCountPagesWithDefault
@@ -105,16 +85,16 @@ struct BookDetailView: View {
                 }
             } else {
                 HStack(alignment: .top, spacing: 32) {
-                    BookCoverView(viewModel: _viewModel, book: book, lastUpdated: book.lastUpdated, presentingReadingSheet: $presentingReadingSheet, alertItem: $_viewModel.alertItem)
+                    BookCoverView(viewModel: _viewModel, book: book, lastUpdated: book.lastUpdated, alertItem: $_viewModel.alertItem)
                     
                     VStack(alignment: .leading, spacing: 16) {
-                        BookMetadataSection(viewModel: _viewModel, book: book, lastUpdated: book.lastUpdated, isCompat: isCompat, readingPositionHistoryViewPresenting: $readingPositionHistoryViewPresenting)
+                        BookMetadataSection(viewModel: _viewModel, book: book, lastUpdated: book.lastUpdated, isCompat: isCompat)
                             .frame(minWidth: 300, maxWidth: 300, alignment: .leading)
                         
-                        BookConnectivitySection(viewModel: _viewModel, book: book, lastUpdated: book.lastUpdated, isCompat: isCompat, activityListViewPresenting: $activityListViewPresenting, alertItem: $_viewModel.alertItem)
+                        BookConnectivitySection(viewModel: _viewModel, book: book, lastUpdated: book.lastUpdated, isCompat: isCompat, alertItem: $_viewModel.alertItem)
                             .frame(minWidth: 300, maxWidth: 300, alignment: .leading)
                         
-                        BookFormatList(viewModel: _viewModel, book: book, lastUpdated: book.lastUpdated, isCompat: isCompat, presentingPreviewSheet: $presentingPreviewSheet)
+                        BookFormatList(viewModel: _viewModel, book: book, lastUpdated: book.lastUpdated, isCompat: isCompat)
                             .frame(minWidth: 300, maxWidth: 300, alignment: .leading)
                         
                         let countPage = book.library.pluginCountPagesWithDefault
@@ -172,7 +152,7 @@ struct BookDetailView: View {
         
         ToolbarItem(placement: .confirmationAction) {
             Button(action: {
-                readingPositionHistoryViewPresenting = true
+                _viewModel.readingPositionHistoryViewPresenting = true
             }) {
                 Image(systemName: "clock")
                     .resizable()

--- a/YetAnotherEBookReader/Views/BookDetailView/BookDetailView.swift
+++ b/YetAnotherEBookReader/Views/BookDetailView/BookDetailView.swift
@@ -92,7 +92,7 @@ struct BookDetailView: View {
                     BookMetadataSection(viewModel: _viewModel, book: book, lastUpdated: book.lastUpdated, isCompat: isCompat, readingPositionHistoryViewPresenting: $readingPositionHistoryViewPresenting)
                         .frame(minWidth: 300, maxWidth: 300, alignment: .leading)
                     
-                    BookConnectivitySection(book: book, lastUpdated: book.lastUpdated, isCompat: isCompat, activityListViewPresenting: $activityListViewPresenting, alertItem: $_viewModel.alertItem)
+                    BookConnectivitySection(viewModel: _viewModel, book: book, lastUpdated: book.lastUpdated, isCompat: isCompat, activityListViewPresenting: $activityListViewPresenting, alertItem: $_viewModel.alertItem)
                         .frame(minWidth: 300, maxWidth: 300, alignment: .leading)
                     
                     BookFormatList(viewModel: _viewModel, book: book, lastUpdated: book.lastUpdated, isCompat: isCompat, presentingPreviewSheet: $presentingPreviewSheet)
@@ -112,7 +112,7 @@ struct BookDetailView: View {
                         BookMetadataSection(viewModel: _viewModel, book: book, lastUpdated: book.lastUpdated, isCompat: isCompat, readingPositionHistoryViewPresenting: $readingPositionHistoryViewPresenting)
                             .frame(minWidth: 300, maxWidth: 300, alignment: .leading)
                         
-                        BookConnectivitySection(book: book, lastUpdated: book.lastUpdated, isCompat: isCompat, activityListViewPresenting: $activityListViewPresenting, alertItem: $_viewModel.alertItem)
+                        BookConnectivitySection(viewModel: _viewModel, book: book, lastUpdated: book.lastUpdated, isCompat: isCompat, activityListViewPresenting: $activityListViewPresenting, alertItem: $_viewModel.alertItem)
                             .frame(minWidth: 300, maxWidth: 300, alignment: .leading)
                         
                         BookFormatList(viewModel: _viewModel, book: book, lastUpdated: book.lastUpdated, isCompat: isCompat, presentingPreviewSheet: $presentingPreviewSheet)

--- a/YetAnotherEBookReader/Views/BookDetailView/BookDetailView.swift
+++ b/YetAnotherEBookReader/Views/BookDetailView/BookDetailView.swift
@@ -14,7 +14,6 @@ import KingfisherSwiftUI
 
 struct BookDetailView: View {
     @EnvironmentObject var modelData: ModelData
-    @EnvironmentObject var downloadManager: BookDownloadManager
     @Environment(\.horizontalSizeClass) var sizeClass
     @Environment(\.openURL) var openURL
     
@@ -160,7 +159,7 @@ struct BookDetailView: View {
             Button(action: {
                 _viewModel.downloadOrClearCache(book: book)
             }) {
-                if let download = downloadManager.activeDownloads.filter( {$1.isDownloading && $1.book.id == book.id} ).first {
+                if let download = _viewModel.activeDownloads.filter( {$1.isDownloading && $1.book.id == book.id} ).first {
                     ProgressView()
                         .progressViewStyle(CircularProgressViewStyle())
                 } else if book.inShelf {

--- a/YetAnotherEBookReader/Views/BookDetailView/BookDetailView.swift
+++ b/YetAnotherEBookReader/Views/BookDetailView/BookDetailView.swift
@@ -29,23 +29,23 @@ struct BookDetailView: View {
     
 
     @State private var presentingReadingSheet = false {
-        willSet { if newValue { modelData.presentingStack.append($presentingReadingSheet) } }
-        didSet { if oldValue { _ = modelData.presentingStack.popLast() } }
+        willSet { if newValue { _viewModel.pushPresenting($presentingReadingSheet) } }
+        didSet { if oldValue { _viewModel.popPresenting() } }
     }
     
     @State private var presentingPreviewSheet = false {
-        willSet { if newValue { modelData.presentingStack.append($presentingPreviewSheet) } }
-        didSet { if oldValue { _ = modelData.presentingStack.popLast() } }
+        willSet { if newValue { _viewModel.pushPresenting($presentingPreviewSheet) } }
+        didSet { if oldValue { _viewModel.popPresenting() } }
     }
     
     @State private var activityListViewPresenting = false {
-        willSet { if newValue { modelData.presentingStack.append($activityListViewPresenting) } }
-        didSet { if oldValue { _ = modelData.presentingStack.popLast() } }
+        willSet { if newValue { _viewModel.pushPresenting($activityListViewPresenting) } }
+        didSet { if oldValue { _viewModel.popPresenting() } }
     }
 
     @State private var readingPositionHistoryViewPresenting = false {
-        willSet { if newValue { modelData.presentingStack.append($readingPositionHistoryViewPresenting) } }
-        didSet { if oldValue { _ = modelData.presentingStack.popLast() } }
+        willSet { if newValue { _viewModel.pushPresenting($readingPositionHistoryViewPresenting) } }
+        didSet { if oldValue { _viewModel.popPresenting() } }
     }
     
     @StateObject private var _viewModel = BookDetailViewModel()
@@ -54,7 +54,7 @@ struct BookDetailView: View {
         
         ScrollView {
             Text(book.title)
-            if let calibreBook = modelData.convert(bookRealm: book) {
+            if let calibreBook = _viewModel.convert(bookRealm: book) {
                 viewContent(book: calibreBook, isCompat: sizeClass == .compact)
                     .onAppear() {
                         _viewModel.setup(modelData: modelData, book: book, calibreBook: calibreBook)
@@ -147,7 +147,7 @@ struct BookDetailView: View {
             Button(action: {
                 _viewModel.refresh(book: book)
             }) {
-                if modelData.updatingMetadata {
+                if _viewModel.updatingMetadata {
                     Image(systemName: "xmark")
                 } else {
                     Image(systemName: "arrow.triangle.2.circlepath")

--- a/YetAnotherEBookReader/Views/BookDetailView/BookDetailViewModel.swift
+++ b/YetAnotherEBookReader/Views/BookDetailView/BookDetailViewModel.swift
@@ -18,6 +18,7 @@ class BookDetailViewModel: ObservableObject {
     private weak var modelData: ModelData?
     var book: CalibreBookRealm?
     private var fetchTask: Task<Void, Never>?
+    @Published var activeDownloads: [URL: BookFormatDownload] = [:]
     var readerInfo: ReaderInfo? {
         return modelData?.readerInfo
     }
@@ -46,6 +47,10 @@ class BookDetailViewModel: ObservableObject {
         
         self.modelData = modelData
         self.book = book
+        
+        if let downloadManager = self.modelData?.downloadManager {
+            downloadManager.$activeDownloads.assign(to: &$activeDownloads)
+        }
         
         if self.listVM == nil {
             self.listVM = ReadingPositionListViewModel(

--- a/YetAnotherEBookReader/Views/BookDetailView/BookDetailViewModel.swift
+++ b/YetAnotherEBookReader/Views/BookDetailView/BookDetailViewModel.swift
@@ -18,6 +18,21 @@ class BookDetailViewModel: ObservableObject {
     private weak var modelData: ModelData?
     var book: CalibreBookRealm?
     private var fetchTask: Task<Void, Never>?
+    var readerInfo: ReaderInfo? {
+        return modelData?.readerInfo
+    }
+    
+    var deviceName: String {
+        return modelData?.deviceName ?? ""
+    }
+    
+    var updatingMetadataStatus: String {
+        return modelData?.updatingMetadataStatus ?? ""
+    }
+    
+    var sharedModelData: ModelData? {
+        return modelData
+    }
     
     init() {
         print("BookDetailViewModel INIT")
@@ -28,6 +43,7 @@ class BookDetailViewModel: ObservableObject {
     }
     
     func setup(modelData: ModelData, book: CalibreBookRealm, calibreBook: CalibreBook) {
+        
         self.modelData = modelData
         self.book = book
         
@@ -104,6 +120,18 @@ class BookDetailViewModel: ObservableObject {
         }
     }
     
+    func pauseDownload(book: CalibreBook, format: Format) {
+        modelData?.pauseDownloadFormat(book: book, format: format)
+    }
+    
+    func resumeDownload(book: CalibreBook, format: Format) {
+        modelData?.resumeDownloadFormat(book: book, format: format)
+    }
+    
+    func cancelDownload(book: CalibreBook, format: Format) {
+        modelData?.cancelDownloadFormat(book: book, format: format)
+    }
+    
     func clearFormat(book: CalibreBook, format: Format) {
         modelData?.clearCache(book: book, format: format)
     }
@@ -166,14 +194,22 @@ class BookDetailViewModel: ObservableObject {
             previewViewModel.toc = String(data: json, encoding: .utf8) ?? "String Decoding Failure"
             #endif
             
-            if let jobStatus = root["job_status"] as? String, jobStatus == "waiting" || jobStatus == "running" {
+            if let jobStatus = root["job_status"] as? String, jobStatus == "waiting" {
                 previewViewModel.toc = "Generating TOC, Please try again later"
             }
             return
         }
         
-        guard let childrenNode = tocNode["children"] as? NSArray else {
-            return
+        previewViewModel.toc = parseTOCNode(node: tocNode, level: 0)
+    }
+    
+    func handlePreviewDismiss(book: CalibreBook) {
+        modelData?.readerInfo = modelData?.prepareBookReading(book: book)
+    }
+
+    func parseTOCNode(node: NSDictionary, level: Int) -> String {
+        guard let childrenNode = node["children"] as? NSArray else {
+            return ""
         }
         
         let tocString = childrenNode.compactMap { childNode -> String? in
@@ -183,6 +219,6 @@ class BookDetailViewModel: ObservableObject {
             return title
         }.joined(separator: "\n") + "\n"
         
-        previewViewModel.toc = tocString
+        return tocString
     }
 }

--- a/YetAnotherEBookReader/Views/BookDetailView/BookDetailViewModel.swift
+++ b/YetAnotherEBookReader/Views/BookDetailView/BookDetailViewModel.swift
@@ -15,6 +15,58 @@ class BookDetailViewModel: ObservableObject {
     
     @Published var alertItem: AlertItem?
     
+    @Published var presentingReadingSheet = false {
+        willSet {
+            if newValue {
+                let binding = Binding<Bool>(
+                    get: { [weak self] in self?.presentingReadingSheet ?? false },
+                    set: { [weak self] in self?.presentingReadingSheet = $0 }
+                )
+                pushPresenting(binding)
+            }
+        }
+        didSet { if oldValue { popPresenting() } }
+    }
+    
+    @Published var presentingPreviewSheet = false {
+        willSet {
+            if newValue {
+                let binding = Binding<Bool>(
+                    get: { [weak self] in self?.presentingPreviewSheet ?? false },
+                    set: { [weak self] in self?.presentingPreviewSheet = $0 }
+                )
+                pushPresenting(binding)
+            }
+        }
+        didSet { if oldValue { popPresenting() } }
+    }
+    
+    @Published var activityListViewPresenting = false {
+        willSet {
+            if newValue {
+                let binding = Binding<Bool>(
+                    get: { [weak self] in self?.activityListViewPresenting ?? false },
+                    set: { [weak self] in self?.activityListViewPresenting = $0 }
+                )
+                pushPresenting(binding)
+            }
+        }
+        didSet { if oldValue { popPresenting() } }
+    }
+
+    @Published var readingPositionHistoryViewPresenting = false {
+        willSet {
+            if newValue {
+                let binding = Binding<Bool>(
+                    get: { [weak self] in self?.readingPositionHistoryViewPresenting ?? false },
+                    set: { [weak self] in self?.readingPositionHistoryViewPresenting = $0 }
+                )
+                pushPresenting(binding)
+            }
+        }
+        didSet { if oldValue { popPresenting() } }
+    }
+    
     private weak var modelData: ModelData?
     var book: CalibreBookRealm?
     private var fetchTask: Task<Void, Never>?

--- a/YetAnotherEBookReader/Views/BookDetailView/BookDetailViewModel.swift
+++ b/YetAnotherEBookReader/Views/BookDetailView/BookDetailViewModel.swift
@@ -6,18 +6,183 @@
 //
 
 import Foundation
-
-extension BookDetailView {
-    @MainActor class ViewModel: ObservableObject {
-        
-    }
-}
+import Combine
+import SwiftUI
 
 class BookDetailViewModel: ObservableObject {
+    @Published var listVM: ReadingPositionListViewModel?
+    @Published var previewViewModel = BookPreviewViewModel()
     
-    var listVM: ReadingPositionListViewModel!
+    @Published var alertItem: AlertItem?
+    
+    private weak var modelData: ModelData?
+    var book: CalibreBookRealm?
+    private var fetchTask: Task<Void, Never>?
     
     init() {
         print("BookDetailViewModel INIT")
+    }
+    
+    deinit {
+        fetchTask?.cancel()
+    }
+    
+    func setup(modelData: ModelData, book: CalibreBookRealm, calibreBook: CalibreBook) {
+        self.modelData = modelData
+        self.book = book
+        
+        if self.listVM == nil {
+            self.listVM = ReadingPositionListViewModel(
+                modelData: modelData, book: calibreBook, positions: calibreBook.readPos.getDevices().sorted(by: { $0.epoch > $1.epoch })
+            )
+        } else {
+            self.listVM?.book = calibreBook
+            self.listVM?.positions = calibreBook.readPos.getDevices().sorted(by: { $0.epoch > $1.epoch })
+        }
+    }
+    
+    func fetchMetadata(book: CalibreBook) {
+        guard let modelData = modelData else { return }
+        fetchTask?.cancel()
+        fetchTask = Task {
+            await modelData.getBooksMetadata(
+                request: .init(
+                    library: book.library,
+                    books: [book.id],
+                    getAnnotations: true
+                )
+            )
+        }
+    }
+    
+    func refresh(book: CalibreBook) {
+        guard let modelData = modelData else { return }
+        if modelData.updatingMetadata {
+            // TODO cancel logic if needed
+        } else {
+            if let coverUrl = book.coverURL {
+                modelData.kfImageCache.removeImage(forKey: coverUrl.absoluteString)
+            }
+            fetchMetadata(book: book)
+        }
+    }
+    
+    func downloadOrClearCache(book: CalibreBook) {
+        guard let modelData = modelData else { return }
+        if book.inShelf {
+            modelData.clearCache(inShelfId: book.inShelfId)
+        } else if modelData.downloadManager.activeDownloads.filter({ $1.isDownloading && $1.book.id == book.id }).isEmpty {
+            if let downloadFormat = modelData.getPreferredFormat(for: book) {
+                modelData.addToShelf(book: book, formats: [downloadFormat])
+            } else {
+                alertItem = AlertItem(id: "Error Download Book", msg: "Sorry, there's no supported book format")
+            }
+        }
+    }
+    
+    func readBook(book: CalibreBook) {
+        guard let modelData = modelData else { return }
+        guard modelData.downloadManager.activeDownloads.filter({ $1.isDownloading && $1.book.id == book.id }).isEmpty else { return }
+        
+        if book.inShelf {
+            modelData.readerInfo = modelData.prepareBookReading(book: book)
+        } else {
+            if let downloadFormat = modelData.getPreferredFormat(for: book) {
+                modelData.addToShelf(book: book, formats: [downloadFormat])
+            } else {
+                alertItem = AlertItem(id: "Error Download Book", msg: "Sorry, there's no supported book format")
+            }
+        }
+    }
+    
+    func cacheFormat(book: CalibreBook, format: Format) {
+        guard let modelData = modelData else { return }
+        if book.inShelf {
+            modelData.startDownloadFormat(book: book, format: format, overwrite: true)
+        } else {
+            modelData.addToShelf(book: book, formats: [format])
+        }
+    }
+    
+    func clearFormat(book: CalibreBook, format: Format) {
+        modelData?.clearCache(book: book, format: format)
+    }
+    
+    func prepareReadingPositionHistory(book: CalibreBook) {
+        guard let modelData = modelData else { return }
+        if listVM == nil {
+            listVM = ReadingPositionListViewModel(
+                modelData: modelData, book: book, positions: book.readPos.getDevices().sorted(by: { $0.epoch > $1.epoch })
+            )
+        } else {
+            listVM?.book = book
+            listVM?.positions = book.readPos.getDevices().sorted(by: { $0.epoch > $1.epoch })
+        }
+    }
+    
+    func previewAction(book: CalibreBook, format: Format, formatInfo: FormatInfo) -> Bool {
+        guard let modelData = modelData else { return false }
+        guard let reader = modelData.formatReaderMap[format]?.first else { return false }
+        guard let bookFileUrl = getSavedUrl(book: book, format: format) else {
+            alertItem = AlertItem(id: "Cannot locate book file", msg: "Please re-download \(format.rawValue)")
+            return false
+        }
+        
+        let readPosition = book.readPos.createInitial(deviceName: modelData.deviceName, reader: reader)
+        
+        modelData.prepareBookReading(
+            url: bookFileUrl,
+            format: format,
+            readerType: reader,
+            position: readPosition
+        )
+        
+        previewViewModel.modelData = modelData
+        previewViewModel.book = book
+        previewViewModel.url = bookFileUrl
+        previewViewModel.format = format
+        previewViewModel.reader = reader
+        previewViewModel.toc = "Initializing"
+        
+        modelData.calibreServerService.getBookManifest(book: book, format: format) { [weak self] data in
+            guard let data = data else { return }
+            self?.parseManifestToTOC(json: data)
+        }
+        return true
+    }
+    
+    func parseManifestToTOC(json: Data) {
+        previewViewModel.toc = "Without TOC"
+        
+        guard let root = try? JSONSerialization.jsonObject(with: json, options: []) as? NSDictionary else {
+            #if DEBUG
+            previewViewModel.toc = String(data: json, encoding: .utf8) ?? "String Decoding Failure"
+            #endif
+            return
+        }
+        
+        guard let tocNode = root["toc"] as? NSDictionary else {
+            #if DEBUG
+            previewViewModel.toc = String(data: json, encoding: .utf8) ?? "String Decoding Failure"
+            #endif
+            
+            if let jobStatus = root["job_status"] as? String, jobStatus == "waiting" || jobStatus == "running" {
+                previewViewModel.toc = "Generating TOC, Please try again later"
+            }
+            return
+        }
+        
+        guard let childrenNode = tocNode["children"] as? NSArray else {
+            return
+        }
+        
+        let tocString = childrenNode.compactMap { childNode -> String? in
+            guard let dict = childNode as? NSDictionary, let title = dict["title"] as? String else {
+                return nil
+            }
+            return title
+        }.joined(separator: "\n") + "\n"
+        
+        previewViewModel.toc = tocString
     }
 }

--- a/YetAnotherEBookReader/Views/BookDetailView/BookDetailViewModel.swift
+++ b/YetAnotherEBookReader/Views/BookDetailView/BookDetailViewModel.swift
@@ -212,6 +212,22 @@ class BookDetailViewModel: ObservableObject {
         modelData?.readerInfo = modelData?.prepareBookReading(book: book)
     }
 
+    func convert(bookRealm: CalibreBookRealm) -> CalibreBook? {
+        return modelData?.convert(bookRealm: bookRealm)
+    }
+
+    var updatingMetadata: Bool {
+        return modelData?.updatingMetadata ?? false
+    }
+
+    func pushPresenting(_ binding: Binding<Bool>) {
+        modelData?.presentingStack.append(binding)
+    }
+
+    func popPresenting() {
+        _ = modelData?.presentingStack.popLast()
+    }
+
     func parseTOCNode(node: NSDictionary, level: Int) -> String {
         guard let childrenNode = node["children"] as? NSArray else {
             return ""

--- a/YetAnotherEBookReader/Views/BookDetailView/BookDetailViewModel.swift
+++ b/YetAnotherEBookReader/Views/BookDetailView/BookDetailViewModel.swift
@@ -87,7 +87,8 @@ class BookDetailViewModel: ObservableObject {
         return modelData
     }
     
-    init() {
+    init(modelData: ModelData? = ModelData.shared) {
+        self.modelData = modelData
         print("BookDetailViewModel INIT")
     }
     
@@ -95,14 +96,15 @@ class BookDetailViewModel: ObservableObject {
         fetchTask?.cancel()
     }
     
-    func setup(modelData: ModelData, book: CalibreBookRealm, calibreBook: CalibreBook) {
-        
-        self.modelData = modelData
+    func setup(book: CalibreBookRealm, calibreBook: CalibreBook) {
         self.book = book
         
-        if let downloadManager = self.modelData?.downloadManager {
-            downloadManager.$activeDownloads.assign(to: &$activeDownloads)
+        guard let modelData = self.modelData else {
+            print("Warning: BookDetailViewModel setup called before modelData was set")
+            return
         }
+        
+        modelData.downloadManager.$activeDownloads.assign(to: &$activeDownloads)
         
         if self.listVM == nil {
             self.listVM = ReadingPositionListViewModel(

--- a/YetAnotherEBookReader/Views/BookDetailView/ReadingPositionDetailView.swift
+++ b/YetAnotherEBookReader/Views/BookDetailView/ReadingPositionDetailView.swift
@@ -12,12 +12,6 @@ struct ReadingPositionDetailView: View {
     
     @State private var overrideToggle = false
     
-    @State private var presentingReadSheet = false {
-        willSet { if newValue { _VM.modelData.presentingStack.append($presentingReadSheet) } }
-        didSet { if oldValue { _ = _VM.modelData.presentingStack.popLast() } }
-    }
-    @State private var alertItem: AlertItem?
-
     init(viewModel: ReadingPositionDetailViewModel) {
         self._VM = viewModel
     }
@@ -87,8 +81,7 @@ struct ReadingPositionDetailView: View {
                 HStack {
                     Picker("Reader", selection: $_VM.selectedFormatReader) {
                         ForEach(ReaderType.allCases) { type in
-                            if let types = _VM.modelData.formatReaderMap[_VM.selectedFormat],
-                               types.contains(type) {
+                            if _VM.availableReaders.contains(type) {
                                 Text(type.rawValue).tag(type)
                             }
                         }
@@ -98,67 +91,29 @@ struct ReadingPositionDetailView: View {
             }
             
             Button(action: {
-                guard let formatInfo = _VM.listModel.book.formats[_VM.selectedFormat.rawValue],
-                      formatInfo.cached else {
-                    alertItem = AlertItem(id: "Selected Format Not Cached", msg: "Please download \(_VM.selectedFormat.rawValue) first")
-                    return
-                }
-                readAction(book: _VM.listModel.book, format: _VM.selectedFormat, formatInfo: formatInfo, reader: _VM.selectedFormatReader)
+                _VM.readSelectedFormat()
             }) {
                 HStack {
                     Spacer()
                     Text("Continue Reading")
                     Spacer()
                 }
-            }.disabled(_VM.listModel.book.formats[_VM.selectedFormat.rawValue]?.cached != true)
+            }.disabled(!_VM.isSelectedFormatCached)
         }
         .navigationTitle(
             Text("\(_VM.position.id) with \(_VM.position.readerName)")
         )
-        .fullScreenCover(isPresented: $presentingReadSheet) {
-            if let book = _VM.modelData.readingBook, let readerInfo = _VM.modelData.readerInfo {
+        .fullScreenCover(isPresented: $_VM.presentingReadSheet) {
+            if let book = _VM.readingBook, let readerInfo = _VM.readerInfo {
                 YabrEBookReader(book: book, readerInfo: readerInfo)
                     .environmentObject(_VM.modelData)
             } else {
                 Text("Nil Book")
             }
         }
-        
-    }
-    
-    func readAction(book: CalibreBook, format: Format, formatInfo: FormatInfo, reader: ReaderType) {
-        guard let bookFileUrl = getSavedUrl(book: book, format: format)
-        else {
-            alertItem = AlertItem(id: "Cannot locate book file", msg: "Please re-download \(format.rawValue)")
-            return
+        .alert(item: $_VM.alertItem) { item in
+            Alert(title: Text(item.id), message: Text(item.msg ?? item.id))
         }
-        
-       _VM.modelData.prepareBookReading(
-            url: bookFileUrl,
-            format: format,
-            readerType: reader,
-            position: _VM.position
-        )
-    
-        presentingReadSheet = true
-    }
-
-    func updatePosition() {
-        _VM.modelData.updateCurrentPosition(alertDelegate: self)
-        
-        if let book = _VM.modelData.readingBook {
-            _VM.listModel.book = book
-            _VM.listModel.positions = book.readPos.getDevices().sorted(by: { $0.epoch > $1.epoch })
-            if let position = book.readPos.getPosition(_VM.position.id) {
-                _VM.position = position
-            }
-        }
-    }
-}
-
-extension ReadingPositionDetailView : AlertDelegate {
-    func alert(alertItem: AlertItem) {
-        self.alertItem = alertItem
     }
 }
 

--- a/YetAnotherEBookReader/Views/BookDetailView/ReadingPositionHistoryView.swift
+++ b/YetAnotherEBookReader/Views/BookDetailView/ReadingPositionHistoryView.swift
@@ -6,50 +6,36 @@
 //
 
 import SwiftUI
-import RealmSwift
 
 #if canImport(SwiftUICharts)
 import SwiftUICharts
 #endif
 
 struct ReadingPositionHistoryView: View {
-    @EnvironmentObject var modelData: ModelData
+    @StateObject private var viewModel: ReadingPositionHistoryViewModel
     
     @Binding var presenting: Bool
     
-    @ObservedResults(BookDeviceReadingPositionRealm.self, configuration: ModelData.shared?.realmConf, where: { !$0.bookId.ends(with: " - History") }) var readingPositions
-
-    let library: CalibreLibrary?
-    let bookId: Int32?
-    
-    //model
-    @State private var readingStatistics = [Double]()
-    @State private var maxMinutes = 0
-    @State private var avgMinutes = 0
-    @State private var _positionViewModel: ReadingPositionListViewModel? = nil
-    @State private var booksHistory = [String: Double]()   //InShelfId to minutes
-    
-    #if canImport(SwiftUICharts)
-    @State private var barChartData: BarChartData?
-    #endif
-    
-    let minutesFormatter = NumberFormatter()
+    init(presenting: Binding<Bool>, library: CalibreLibrary?, bookId: Int32?) {
+        self._presenting = presenting
+        self._viewModel = StateObject(wrappedValue: ReadingPositionHistoryViewModel(library: library, bookId: bookId))
+    }
     
     var body: some View {
         VStack {
             Group {
-                if readingStatistics.isEmpty {
+                if viewModel.readingStatistics.isEmpty {
                     Text("New Book")
                 } else {
                     #if DEBUG
                     List {
-                        ForEach(readingStatistics, id: \.self) { minutes in
+                        ForEach(viewModel.readingStatistics, id: \.self) { minutes in
                             Text("\(minutes)")
                         }
                     }
                     #endif
                     #if canImport(SwiftUICharts)
-                    if let data = barChartData {
+                    if let data = viewModel.barChartData {
                         BarChart(
                             chartData: data
                         )
@@ -86,42 +72,35 @@ struct ReadingPositionHistoryView: View {
 //                }
                 
                 #if DEBUG
-                Text("BookId: \(bookId ?? -1)")
-                Text("Library: \(library?.id ?? "NO LIB")")
-                if let bookId = bookId,
-                   let library = library {
-                    ForEach(readingPositions.where({
-                        $0.bookId.starts(
-                            with: BookAnnotation.PrefId(library: library, id: bookId)
-                        )
-                    })) { readingPosition in
-                        HStack {
-                            Text(readingPosition.deviceId)
-                            Text(readingPosition.lastReadChapter)
-                            Text("\(readingPosition.lastProgress)")
-                        }
+                Text("BookId: \(viewModel.bookId ?? -1)")
+                Text("Library: \(viewModel.library?.id ?? "NO LIB")")
+                ForEach(viewModel.debugReadingPositions, id: \.id) { readingPosition in
+                    HStack {
+                        Text(readingPosition.id)
+                        Text(readingPosition.lastReadChapter)
+                        Text("\(readingPosition.lastProgress)")
                     }
                 }
                 #endif
                 
-                if let viewModel = _positionViewModel {
-                    if viewModel.positions.isEmpty == false {
-                        ForEach(viewModel.positionsDeviceKeys(), id: \.self) { deviceId in
+                if let listVM = viewModel.listViewModel {
+                    if listVM.positions.isEmpty == false {
+                        ForEach(listVM.positionsDeviceKeys(), id: \.self) { deviceId in
                             Section(
                                 header: HStack {
                                     Text("On \(deviceId)")
                                     Spacer()
-                                    if deviceId == modelData.deviceName {
+                                    if deviceId == viewModel.modelData.deviceName {
                                         Text("This Device").foregroundColor(.red)
                                     }
                                 }
                             ) {
-                                ForEach(viewModel.positionsByLatestStyle(deviceId: deviceId), id: \.hashValue) { position in
+                                ForEach(listVM.positionsByLatestStyle(deviceId: deviceId), id: \.hashValue) { position in
                                     NavigationLink(
                                         destination: ReadingPositionDetailView(
                                             viewModel: ReadingPositionDetailViewModel(
-                                                modelData: modelData,
-                                                listModel: _positionViewModel!,
+                                                modelData: viewModel.modelData,
+                                                listModel: listVM,
                                                 position: position)
                                         )
                                     ) {
@@ -138,8 +117,8 @@ struct ReadingPositionHistoryView: View {
                             Text("Start Reading Now")
                             
                         }
-                        Text(getSavedUrl(book: viewModel.book, format: Format.EPUB)?.absoluteString ?? "NO URL")
-                        Text(getBookBaseUrl(id: viewModel.book.id, library: viewModel.book.library, localFilename: viewModel.book.formats.first?.value.filename)?.absoluteString ?? "NIL")
+                        Text(getSavedUrl(book: listVM.book, format: Format.EPUB)?.absoluteString ?? "NO URL")
+                        Text(getBookBaseUrl(id: listVM.book.id, library: listVM.book.library, localFilename: listVM.book.formats.first?.value.filename)?.absoluteString ?? "NIL")
                         #endif
                     }
                 } else {
@@ -151,33 +130,32 @@ struct ReadingPositionHistoryView: View {
                 }
                 
                 Section(header: Text("Local Activities")) {
-                    if let library = library, let bookId = bookId {
-                        if let viewModel = _positionViewModel {
-                            ForEach(modelData.listBookDeviceReadingPositionHistory(library: library, bookId: bookId).first?.value ?? [], id: \.self) { obj in
-                                NavigationLink(
-                                    destination: ReadingPositionDetailView(
-                                        viewModel: ReadingPositionDetailViewModel(
-                                            modelData: modelData,
-                                            listModel: viewModel,
-                                            position: obj.endPosition!)
-                                    )
-                                ) {
-                                    row(position: obj.endPosition!)
+                    if viewModel.library != nil, viewModel.bookId != nil {
+                        if let listVM = viewModel.listViewModel {
+                            ForEach(viewModel.localActivities, id: \.self) { obj in
+                                if let endPos = obj.endPosition {
+                                    NavigationLink(
+                                        destination: ReadingPositionDetailView(
+                                            viewModel: ReadingPositionDetailViewModel(
+                                                modelData: viewModel.modelData,
+                                                listModel: listVM,
+                                                position: endPos)
+                                        )
+                                    ) {
+                                        row(position: endPos)
+                                    }
                                 }
                             }
                         }
                     } else {
-                        ForEach(booksHistory.sorted(by: { $0.value > $1.value }), id: \.key) { inShelfId, minutes in
-                            if let book = modelData.booksInShelf[inShelfId],
-                               let minutesText = minutesFormatter.string(from: NSNumber(value: minutes)) {
-                                NavigationLink(
-                                    destination: ReadingPositionHistoryView(presenting: Binding<Bool>(get: { false }, set: { _ in }), library: book.library, bookId: book.id)
-                                ) {
-                                    HStack {
-                                        Text(book.title)
-                                        Spacer()
-                                        Text(minutesText)
-                                    }
+                        ForEach(viewModel.booksHistoryItems) { item in
+                            NavigationLink(
+                                destination: ReadingPositionHistoryView(presenting: Binding<Bool>(get: { false }, set: { _ in }), library: item.book.library, bookId: item.book.id)
+                            ) {
+                                HStack {
+                                    Text(item.book.title)
+                                    Spacer()
+                                    Text(item.minutesText)
                                 }
                             }
                         }
@@ -186,55 +164,7 @@ struct ReadingPositionHistoryView: View {
             }
         }
         .onAppear {
-            let limitDays = 7
-            let startDate = Calendar.current.startOfDay(for: Date(timeIntervalSinceNow: Double(-86400 * (limitDays))))
-            
-            let readingHistoryList = modelData.listBookDeviceReadingPositionHistory(library: library, bookId: bookId, startDateAfter: startDate)
-            
-            readingStatistics = modelData.getReadingStatistics(list: readingHistoryList.flatMap({ $0.value }), limitDays: limitDays)
-            maxMinutes = Int(readingStatistics.dropLast().max() ?? 0)
-            avgMinutes = Int(readingStatistics.dropLast().reduce(0.0,+) / Double(readingStatistics.count - 1))
-            
-            #if canImport(SwiftUICharts)
-            barChartData = .init(
-                dataSets: .init(
-                    dataPoints: readingStatistics.map({
-                        .init(value: $0)
-                    }),
-                    legendTitle: "Minutes"
-                ),
-                metadata: .init(
-                    title: "Weekly Read Time",
-                    subtitle: "Minutes"
-                )
-            )
-            #endif
-            
-            print("\(#function) readingStatistics=\(readingStatistics)")
-            
-            minutesFormatter.maximumFractionDigits = 1
-            minutesFormatter.minimumFractionDigits = 1
-            
-            if let library = library, let bookId = bookId {
-                if let bookRealm = modelData.queryBookRealm(book: CalibreBook(id: bookId, library: library), realm: modelData.realm),
-                   let book = modelData.convert(bookRealm: bookRealm) {
-                    _positionViewModel = ReadingPositionListViewModel(modelData: modelData, book: book, positions: book.readPos.getDevices())
-                } else if let book = modelData.readingBook {
-                    _positionViewModel = ReadingPositionListViewModel(modelData: modelData, book: book, positions: book.readPos.getDevices())
-                }
-            }
-            else {
-                self.booksHistory = readingHistoryList.reduce(into: [:], { partialResult, entry in
-                    let inShelfId = entry.key
-                    entry.value.forEach {
-                        guard let endPosition = $0.endPosition else { return }
-                        let duration = endPosition.epoch - $0.startDatetime.timeIntervalSince1970
-                        if duration > 0 {
-                            partialResult[inShelfId] = (partialResult[inShelfId] ?? 0.0) + (duration / 60.0)
-                        }
-                    }
-                })
-            }
+            viewModel.loadData()
         }
         .navigationTitle("Reading History")
         .navigationBarTitleDisplayMode(.inline)
@@ -250,12 +180,12 @@ struct ReadingPositionHistoryView: View {
             HStack {
                 if position.structuralStyle != 0, position.lastReadBook.isEmpty == false {
                     Text(position.lastReadBook)
-                    if let percent = _positionViewModel?.percentFormatter.string(from: NSNumber(value: position.lastProgress / 100)) {
+                    if let percent = viewModel.listViewModel?.percentFormatter.string(from: NSNumber(value: position.lastProgress / 100)) {
                         Text("(\(percent))")
                     }
                 } else {
                     Text(position.lastReadChapter)
-                    if let percent = _positionViewModel?.percentFormatter.string(from: NSNumber(value: position.lastChapterProgress / 100)) {
+                    if let percent = viewModel.listViewModel?.percentFormatter.string(from: NSNumber(value: position.lastChapterProgress / 100)) {
                         Text("(\(percent))")
                     }
                 }
@@ -267,7 +197,7 @@ struct ReadingPositionHistoryView: View {
                 Spacer()
                 if position.structuralStyle != 0, position.lastReadBook.isEmpty == false {
                     Text(position.lastReadChapter)
-                    if let percent = _positionViewModel?.percentFormatter.string(from: NSNumber(value: position.lastChapterProgress / 100)) {
+                    if let percent = viewModel.listViewModel?.percentFormatter.string(from: NSNumber(value: position.lastChapterProgress / 100)) {
                         Text("(\(percent))")
                     }
                 }

--- a/YetAnotherEBookReader/Views/BookDetailView/ReadingPositionViewModel.swift
+++ b/YetAnotherEBookReader/Views/BookDetailView/ReadingPositionViewModel.swift
@@ -6,6 +6,12 @@
 //
 
 import Foundation
+import SwiftUI
+import RealmSwift
+
+#if canImport(SwiftUICharts)
+import SwiftUICharts
+#endif
 
 class ReadingPositionListViewModel: ObservableObject {
     @Published var modelData: ModelData
@@ -58,7 +64,7 @@ class ReadingPositionListViewModel: ObservableObject {
     }
 }
 
-class ReadingPositionDetailViewModel: ObservableObject {
+class ReadingPositionDetailViewModel: ObservableObject, AlertDelegate {
     @Published var modelData: ModelData
     @Published var listModel: ReadingPositionListViewModel
     @Published var position: BookDeviceReadingPosition
@@ -66,6 +72,24 @@ class ReadingPositionDetailViewModel: ObservableObject {
     @Published var selectedFormat = Format.UNKNOWN
     @Published var selectedFormatReader = ReaderType.UNSUPPORTED
     @Published var startPage = ""
+    @Published var alertItem: AlertItem?
+    
+    @Published var presentingReadSheet = false {
+        willSet {
+            if newValue {
+                let binding = Binding<Bool>(
+                    get: { [weak self] in self?.presentingReadSheet ?? false },
+                    set: { [weak self] in self?.presentingReadSheet = $0 }
+                )
+                modelData.presentingStack.append(binding)
+            }
+        }
+        didSet {
+            if oldValue {
+                _ = modelData.presentingStack.popLast()
+            }
+        }
+    }
     
     let percentFormatter = NumberFormatter()
     let dateFormatter = DateFormatter()
@@ -91,6 +115,164 @@ class ReadingPositionDetailViewModel: ObservableObject {
         dateFormatter.dateStyle = .medium
         dateFormatter.timeStyle = .medium
         dateFormatter.timeZone = .current
+    }
+    
+    func alert(alertItem: AlertItem) {
+        self.alertItem = alertItem
+    }
+    
+    var availableReaders: [ReaderType] {
+        return modelData.formatReaderMap[selectedFormat] ?? []
+    }
+    
+    var readingBook: CalibreBook? {
+        return modelData.readingBook
+    }
+    
+    var readerInfo: ReaderInfo? {
+        return modelData.readerInfo
+    }
+    
+    var isSelectedFormatCached: Bool {
+        return listModel.book.formats[selectedFormat.rawValue]?.cached == true
+    }
+    
+    func readSelectedFormat() {
+        let book = listModel.book
+        let format = selectedFormat
+        guard let formatInfo = book.formats[format.rawValue],
+              formatInfo.cached else {
+            alertItem = AlertItem(id: "Selected Format Not Cached", msg: "Please download \(format.rawValue) first")
+            return
+        }
+        
+        guard let bookFileUrl = getSavedUrl(book: book, format: format) else {
+            alertItem = AlertItem(id: "Cannot locate book file", msg: "Please re-download \(format.rawValue)")
+            return
+        }
+        
+        modelData.prepareBookReading(
+            url: bookFileUrl,
+            format: format,
+            readerType: selectedFormatReader,
+            position: position
+        )
+        
+        presentingReadSheet = true
+    }
+
+    func updatePosition() {
+        modelData.updateCurrentPosition(alertDelegate: self)
+        
+        if let book = modelData.readingBook {
+            listModel.book = book
+            listModel.positions = book.readPos.getDevices().sorted(by: { $0.epoch > $1.epoch })
+            if let position = book.readPos.getPosition(self.position.id) {
+                self.position = position
+            }
+        }
+    }
+}
+
+struct BookHistoryItem: Identifiable {
+    var id: String { inShelfId }
+    let inShelfId: String
+    let book: CalibreBook
+    let minutesText: String
+}
+
+class ReadingPositionHistoryViewModel: ObservableObject {
+    @Published var modelData: ModelData
+    let library: CalibreLibrary?
+    let bookId: Int32?
+    
+    @Published var readingStatistics = [Double]()
+    @Published var maxMinutes = 0
+    @Published var avgMinutes = 0
+    @Published var listViewModel: ReadingPositionListViewModel? = nil
+    @Published var localActivities = [BookDeviceReadingPositionHistory]()
+    @Published var booksHistoryItems = [BookHistoryItem]()
+    @Published var debugReadingPositions = [BookDeviceReadingPosition]()
+    
+    #if canImport(SwiftUICharts)
+    @Published var barChartData: BarChartData?
+    #endif
+    
+    let minutesFormatter = NumberFormatter()
+    
+    init(modelData: ModelData = ModelData.shared ?? ModelData(mock: true), library: CalibreLibrary?, bookId: Int32?) {
+        self.modelData = modelData
+        self.library = library
+        self.bookId = bookId
+        
+        minutesFormatter.maximumFractionDigits = 1
+        minutesFormatter.minimumFractionDigits = 1
+    }
+    
+    func loadData() {
+        let limitDays = 7
+        let startDate = Calendar.current.startOfDay(for: Date(timeIntervalSinceNow: Double(-86400 * (limitDays))))
+        
+        let readingHistoryList = modelData.listBookDeviceReadingPositionHistory(library: library, bookId: bookId, startDateAfter: startDate)
+        
+        readingStatistics = modelData.getReadingStatistics(list: readingHistoryList.flatMap({ $0.value }), limitDays: limitDays)
+        maxMinutes = Int(readingStatistics.dropLast().max() ?? 0)
+        avgMinutes = Int(readingStatistics.dropLast().reduce(0.0,+) / Double(readingStatistics.count - 1))
+        
+        #if canImport(SwiftUICharts)
+        barChartData = .init(
+            dataSets: .init(
+                dataPoints: readingStatistics.map({
+                    .init(value: $0)
+                }),
+                legendTitle: "Minutes"
+            ),
+            metadata: .init(
+                title: "Weekly Read Time",
+                subtitle: "Minutes"
+            )
+        )
+        #endif
+        
+        print("\(#function) readingStatistics=\(readingStatistics)")
+        
+        if let library = library, let bookId = bookId {
+            localActivities = modelData.listBookDeviceReadingPositionHistory(library: library, bookId: bookId).first?.value ?? []
+            
+            if let bookRealm = modelData.queryBookRealm(book: CalibreBook(id: bookId, library: library), realm: modelData.realm),
+               let book = modelData.convert(bookRealm: bookRealm) {
+                listViewModel = ReadingPositionListViewModel(modelData: modelData, book: book, positions: book.readPos.getDevices())
+            } else if let book = modelData.readingBook {
+                listViewModel = ReadingPositionListViewModel(modelData: modelData, book: book, positions: book.readPos.getDevices())
+            }
+            
+            // Debug reading positions
+            if let realm = modelData.realm {
+                let prefix = BookAnnotation.PrefId(library: library, id: bookId)
+                let objs = realm.objects(BookDeviceReadingPositionRealm.self)
+                    .filter("NOT bookId ENDSWITH ' - History' AND bookId BEGINSWITH %@", prefix)
+                self.debugReadingPositions = objs.map { BookDeviceReadingPosition(managedObject: $0) }
+            }
+        } else {
+            let computedHistory = readingHistoryList.reduce(into: [String: Double](), { partialResult, entry in
+                let inShelfId = entry.key
+                entry.value.forEach {
+                    guard let endPosition = $0.endPosition else { return }
+                    let duration = endPosition.epoch - $0.startDatetime.timeIntervalSince1970
+                    if duration > 0 {
+                        partialResult[inShelfId] = (partialResult[inShelfId] ?? 0.0) + (duration / 60.0)
+                    }
+                }
+            })
+            
+            self.booksHistoryItems = computedHistory.sorted(by: { $0.value > $1.value }).compactMap { entry -> BookHistoryItem? in
+                guard let book = modelData.booksInShelf[entry.key],
+                      let minutesText = minutesFormatter.string(from: NSNumber(value: entry.value)) else {
+                    return nil
+                }
+                return BookHistoryItem(inShelfId: entry.key, book: book, minutesText: minutesText)
+            }
+        }
     }
 }
 

--- a/YetAnotherEBookReader/Views/SettingsView/ServerView/LibraryDetailView.swift
+++ b/YetAnotherEBookReader/Views/SettingsView/ServerView/LibraryDetailView.swift
@@ -31,7 +31,7 @@ struct LibraryDetailView: View {
             
             Section(header: Text("Troubleshooting")) {
                 NavigationLink(
-                    destination: ActivityList(presenting: Binding<Bool>(get: { false }, set:{_ in }), libraryId: library.id, bookId: nil)
+                    destination: ActivityList(viewModel: ActivityListViewModel(modelData: modelData, libraryId: library.id, bookId: nil), presenting: Binding<Bool>(get: { false }, set:{_ in }))
                 ) {
                     Text("Activity Logs")
                 }

--- a/YetAnotherEBookReader/Views/SettingsView/SettingsView.swift
+++ b/YetAnotherEBookReader/Views/SettingsView/SettingsView.swift
@@ -104,7 +104,7 @@ struct SettingsView: View {
             Section(header: Text("More")) {
                 NavigationLink("Readers Options", destination: ReaderOptionsView())
                 NavigationLink("Reading Statistics", destination: LazyView(ReadingPositionHistoryView(presenting: Binding<Bool>(get: { false }, set: { _ in }), library: nil, bookId: nil)))
-                NavigationLink("Activity Logs", destination: LazyView(ActivityList(presenting: Binding<Bool>(get: { false }, set: { _ in } ))))
+                NavigationLink("Activity Logs", destination: LazyView(ActivityList(viewModel: ActivityListViewModel(modelData: modelData), presenting: Binding<Bool>(get: { false }, set: { _ in } ))))
             }
             
             Section(

--- a/YetAnotherEBookReader/Views/ShelfView/RecentShelfController.swift
+++ b/YetAnotherEBookReader/Views/ShelfView/RecentShelfController.swift
@@ -305,6 +305,7 @@ class RecentShelfController: UIViewController, PlainShelfViewDelegate {
             
             let bookDetailView = BookDetailView(book: bookRealm, viewMode: .SHELF)
                 .environmentObject(modelData)
+                .environmentObject(modelData.downloadManager)
                 .environment(\.realmConfiguration, bookAnnoRealm.configuration)
             
             let detailView = UIHostingController(

--- a/YetAnotherEBookReader/Views/ShelfView/SectionShelfController.swift
+++ b/YetAnotherEBookReader/Views/ShelfView/SectionShelfController.swift
@@ -511,7 +511,9 @@ class SectionShelfController: UIViewController, SectionShelfCompositionalViewDel
             return
         }
         
-        let bookDetailView = BookDetailView(book: bookRealm, viewMode: .SHELF).environmentObject(modelData)
+        let bookDetailView = BookDetailView(book: bookRealm, viewMode: .SHELF)
+            .environmentObject(modelData)
+            .environmentObject(modelData.downloadManager)
         let detailView = UIHostingController(
             rootView: bookDetailView
         )
@@ -541,7 +543,9 @@ class SectionShelfController: UIViewController, SectionShelfCompositionalViewDel
             return
         }
         
-        let bookDetailView = BookDetailView(book: bookRealm, viewMode: .SHELF).environmentObject(modelData)
+        let bookDetailView = BookDetailView(book: bookRealm, viewMode: .SHELF)
+            .environmentObject(modelData)
+            .environmentObject(modelData.downloadManager)
         let detailView = UIHostingController(
             rootView: bookDetailView
         )

--- a/YetAnotherEBookReaderTests/BookDetailViewModelTests.swift
+++ b/YetAnotherEBookReaderTests/BookDetailViewModelTests.swift
@@ -11,7 +11,7 @@ class BookDetailViewModelTests: XCTestCase {
     
     override func setUpWithError() throws {
         mockModelData = ModelData(mock: true)
-        viewModel = BookDetailViewModel()
+        viewModel = BookDetailViewModel(modelData: mockModelData)
         
         mockBookRealm = CalibreBookRealm()
         mockBookRealm.serverUUID = "mock-uuid"
@@ -23,7 +23,7 @@ class BookDetailViewModelTests: XCTestCase {
         mockCalibreBook = CalibreBook(id: 123, library: library)
         mockCalibreBook.title = "Test Book"
         
-        viewModel.setup(modelData: mockModelData, book: mockBookRealm, calibreBook: mockCalibreBook)
+        viewModel.setup(book: mockBookRealm, calibreBook: mockCalibreBook)
     }
 
     override func tearDownWithError() throws {

--- a/YetAnotherEBookReaderTests/BookDetailViewModelTests.swift
+++ b/YetAnotherEBookReaderTests/BookDetailViewModelTests.swift
@@ -192,3 +192,20 @@ class ReadingPositionViewModelTests: XCTestCase {
         XCTAssertNotNil(historyVM.readingStatistics)
     }
 }
+
+class ActivityListViewModelTests: XCTestCase {
+    var mockModelData: ModelData!
+    
+    override func setUpWithError() throws {
+        mockModelData = ModelData(mock: true)
+    }
+    
+    override func tearDownWithError() throws {
+        mockModelData = nil
+    }
+    
+    func testInitialization() throws {
+        let viewModel = ActivityListViewModel(modelData: mockModelData)
+        XCTAssertEqual(viewModel.activities.count, 0)
+    }
+}

--- a/YetAnotherEBookReaderTests/BookDetailViewModelTests.swift
+++ b/YetAnotherEBookReaderTests/BookDetailViewModelTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+@testable import YetAnotherEBookReader
+
+class BookDetailViewModelTests: XCTestCase {
+    
+    var viewModel: BookDetailViewModel!
+    var mockModelData: ModelData!
+    var mockBookRealm: CalibreBookRealm!
+    var mockCalibreBook: CalibreBook!
+    
+    override func setUpWithError() throws {
+        mockModelData = ModelData(mock: true)
+        viewModel = BookDetailViewModel()
+        
+        mockBookRealm = CalibreBookRealm()
+        mockBookRealm.serverUUID = "mock-uuid"
+        mockBookRealm.libraryName = "Mock Library"
+        mockBookRealm.idInLib = 123
+        mockBookRealm.title = "Test Book"
+        
+        let library = CalibreLibrary(server: CalibreServer(uuid: UUID(), name: "MockServer", baseUrl: "http://localhost", hasPublicUrl: false, publicUrl: "", hasAuth: false, username: "", password: ""), key: "lib1", name: "Mock Library")
+        mockCalibreBook = CalibreBook(id: 123, library: library)
+        mockCalibreBook.title = "Test Book"
+        
+        viewModel.setup(modelData: mockModelData, book: mockBookRealm, calibreBook: mockCalibreBook)
+    }
+
+    override func tearDownWithError() throws {
+        viewModel = nil
+        mockModelData = nil
+        mockBookRealm = nil
+        mockCalibreBook = nil
+    }
+
+    func testViewModelSetup() throws {
+        XCTAssertNotNil(viewModel.listVM)
+        XCTAssertEqual(viewModel.listVM?.book.id, 123)
+        XCTAssertEqual(viewModel.listVM?.book.title, "Test Book")
+    }
+    
+    func testReadBookWhenNotInShelf() throws {
+        mockCalibreBook.inShelf = false
+        viewModel.readBook(book: mockCalibreBook)
+        XCTAssertNotNil(viewModel.alertItem, "Alert item should be set if there is no format to download")
+    }
+    
+    func testReadBookWhenInShelf() throws {
+        mockCalibreBook.inShelf = true
+        viewModel.readBook(book: mockCalibreBook)
+        XCTAssertNotNil(mockModelData.readerInfo, "Reader info should be populated when reading an in-shelf book")
+    }
+    
+    func testParseManifestToTOCSuccess() throws {
+        let jsonString = "{\"toc\": {\"children\": [{\"title\": \"Chapter 1\"}, {\"title\": \"Chapter 2\"}]}}"
+        let data = jsonString.data(using: .utf8)!
+        viewModel.parseManifestToTOC(json: data)
+        XCTAssertEqual(viewModel.previewViewModel.toc, "Chapter 1\nChapter 2\n", "TOC should be correctly parsed from manifest JSON")
+    }
+    
+    func testParseManifestToTOCWaiting() throws {
+        let jsonString = "{\"job_status\": \"waiting\"}"
+        let data = jsonString.data(using: .utf8)!
+        viewModel.parseManifestToTOC(json: data)
+        XCTAssertEqual(viewModel.previewViewModel.toc, "Generating TOC, Please try again later", "Should show generating message when job is waiting")
+    }
+    
+    func testParseManifestToTOCInvalidJSON() throws {
+        let data = "Invalid JSON".data(using: .utf8)!
+        viewModel.parseManifestToTOC(json: data)
+        #if DEBUG
+        XCTAssertEqual(viewModel.previewViewModel.toc, "Invalid JSON", "Should fallback to raw string for invalid JSON in DEBUG")
+        #else
+        XCTAssertEqual(viewModel.previewViewModel.toc, "Without TOC", "Should fallback to Without TOC for invalid JSON")
+        #endif
+    }
+}

--- a/YetAnotherEBookReaderTests/BookDetailViewModelTests.swift
+++ b/YetAnotherEBookReaderTests/BookDetailViewModelTests.swift
@@ -100,4 +100,44 @@ class BookDetailViewModelTests: XCTestCase {
         let result = viewModel.convert(bookRealm: mockBookRealm)
         XCTAssertNil(result, "Should return nil if library is not queryable in mock model data")
     }
+
+    func testPresentationSheetProperties() throws {
+        XCTAssertEqual(mockModelData.presentingStack.count, 0)
+        
+        viewModel.presentingReadingSheet = true
+        XCTAssertEqual(mockModelData.presentingStack.count, 1)
+        viewModel.presentingReadingSheet = false
+        XCTAssertEqual(mockModelData.presentingStack.count, 0)
+        
+        viewModel.presentingPreviewSheet = true
+        XCTAssertEqual(mockModelData.presentingStack.count, 1)
+        viewModel.presentingPreviewSheet = false
+        XCTAssertEqual(mockModelData.presentingStack.count, 0)
+        
+        viewModel.activityListViewPresenting = true
+        XCTAssertEqual(mockModelData.presentingStack.count, 1)
+        viewModel.activityListViewPresenting = false
+        XCTAssertEqual(mockModelData.presentingStack.count, 0)
+        
+        viewModel.readingPositionHistoryViewPresenting = true
+        XCTAssertEqual(mockModelData.presentingStack.count, 1)
+        viewModel.readingPositionHistoryViewPresenting = false
+        XCTAssertEqual(mockModelData.presentingStack.count, 0)
+    }
+
+    func testPresentationSheetPropertiesBindingInteractions() throws {
+        XCTAssertEqual(mockModelData.presentingStack.count, 0)
+        
+        viewModel.presentingReadingSheet = true
+        XCTAssertEqual(mockModelData.presentingStack.count, 1)
+        
+        let binding = mockModelData.presentingStack.last
+        XCTAssertNotNil(binding)
+        XCTAssertTrue(binding?.wrappedValue ?? false)
+        
+        // Dismiss via binding (e.g. SwiftUI sheet dismissal)
+        binding?.wrappedValue = false
+        XCTAssertFalse(viewModel.presentingReadingSheet)
+        XCTAssertEqual(mockModelData.presentingStack.count, 0)
+    }
 }

--- a/YetAnotherEBookReaderTests/BookDetailViewModelTests.swift
+++ b/YetAnotherEBookReaderTests/BookDetailViewModelTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import SwiftUI
 @testable import YetAnotherEBookReader
 
 class BookDetailViewModelTests: XCTestCase {
@@ -72,5 +73,31 @@ class BookDetailViewModelTests: XCTestCase {
         #else
         XCTAssertEqual(viewModel.previewViewModel.toc, "Without TOC", "Should fallback to Without TOC for invalid JSON")
         #endif
+    }
+
+    func testUpdatingMetadata() throws {
+        XCTAssertFalse(viewModel.updatingMetadata)
+        mockModelData.updatingMetadata = true
+        XCTAssertTrue(viewModel.updatingMetadata)
+    }
+
+    func testPushAndPopPresenting() throws {
+        var presenting = false
+        let binding = Binding<Bool>(
+            get: { presenting },
+            set: { presenting = $0 }
+        )
+        
+        XCTAssertEqual(mockModelData.presentingStack.count, 0)
+        viewModel.pushPresenting(binding)
+        XCTAssertEqual(mockModelData.presentingStack.count, 1)
+        
+        viewModel.popPresenting()
+        XCTAssertEqual(mockModelData.presentingStack.count, 0)
+    }
+
+    func testConvertBookRealm() throws {
+        let result = viewModel.convert(bookRealm: mockBookRealm)
+        XCTAssertNil(result, "Should return nil if library is not queryable in mock model data")
     }
 }

--- a/YetAnotherEBookReaderTests/BookDetailViewModelTests.swift
+++ b/YetAnotherEBookReaderTests/BookDetailViewModelTests.swift
@@ -141,3 +141,54 @@ class BookDetailViewModelTests: XCTestCase {
         XCTAssertEqual(mockModelData.presentingStack.count, 0)
     }
 }
+
+class ReadingPositionViewModelTests: XCTestCase {
+    var mockModelData: ModelData!
+    var listViewModel: ReadingPositionListViewModel!
+    var mockBook: CalibreBook!
+    
+    override func setUpWithError() throws {
+        mockModelData = ModelData(mock: true)
+        
+        let library = CalibreLibrary(server: CalibreServer(uuid: UUID(), name: "MockServer", baseUrl: "http://localhost", hasPublicUrl: false, publicUrl: "", hasAuth: false, username: "", password: ""), key: "lib1", name: "Mock Library")
+        mockBook = CalibreBook(id: 123, library: library)
+        mockBook.title = "Test Book"
+        
+        listViewModel = ReadingPositionListViewModel(modelData: mockModelData, book: mockBook, positions: [])
+    }
+    
+    override func tearDownWithError() throws {
+        listViewModel = nil
+        mockBook = nil
+        mockModelData = nil
+    }
+    
+    func testDetailViewModelInitialization() throws {
+        let position = BookDeviceReadingPosition(id: "device-1", readerName: ReaderType.YabrEPUB.rawValue)
+        let detailVM = ReadingPositionDetailViewModel(modelData: mockModelData, listModel: listViewModel, position: position)
+        
+        XCTAssertEqual(detailVM.position.id, "device-1")
+        XCTAssertEqual(detailVM.selectedFormatReader, .YabrEPUB)
+        XCTAssertEqual(detailVM.selectedFormat, .EPUB)
+    }
+    
+    func testDetailViewModelPresentingSheet() throws {
+        let position = BookDeviceReadingPosition(id: "device-1", readerName: ReaderType.YabrEPUB.rawValue)
+        let detailVM = ReadingPositionDetailViewModel(modelData: mockModelData, listModel: listViewModel, position: position)
+        
+        XCTAssertEqual(mockModelData.presentingStack.count, 0)
+        detailVM.presentingReadSheet = true
+        XCTAssertEqual(mockModelData.presentingStack.count, 1)
+        detailVM.presentingReadSheet = false
+        XCTAssertEqual(mockModelData.presentingStack.count, 0)
+    }
+    
+    func testHistoryViewModelLoadData() throws {
+        let historyVM = ReadingPositionHistoryViewModel(modelData: mockModelData, library: mockBook.library, bookId: mockBook.id)
+        XCTAssertEqual(historyVM.maxMinutes, 0)
+        
+        historyVM.loadData()
+        
+        XCTAssertNotNil(historyVM.readingStatistics)
+    }
+}

--- a/YetAnotherEBookReaderTests/Info.plist
+++ b/YetAnotherEBookReaderTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>BNDL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+</dict>
+</plist>

--- a/YetAnotherEBookReaderTests/YetAnotherEBookReaderTests.swift
+++ b/YetAnotherEBookReaderTests/YetAnotherEBookReaderTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import YetAnotherEBookReader
+
+class YetAnotherEBookReaderTests: XCTestCase {
+    func testExample() throws {
+        XCTAssertTrue(true)
+    }
+}

--- a/YetAnotherEBookReaderUITests/Info.plist
+++ b/YetAnotherEBookReaderUITests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>BNDL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+</dict>
+</plist>

--- a/YetAnotherEBookReaderUITests/YetAnotherEBookReaderUITests.swift
+++ b/YetAnotherEBookReaderUITests/YetAnotherEBookReaderUITests.swift
@@ -1,0 +1,8 @@
+import XCTest
+
+class YetAnotherEBookReaderUITests: XCTestCase {
+    func testExample() throws {
+        let app = XCUIApplication()
+        app.launch()
+    }
+}


### PR DESCRIPTION
## Summary
- Refactor the book detail experience toward MVVM, splitting view logic into dedicated view models and subviews.
- Update activity and reading-position presentation to use the new structure.
- Adjust related shelf, settings, and model code to align with the refactor.
- Add and update tests for book detail behavior.

## Testing
- Added/updated unit coverage for `BookDetailViewModel`.
- Updated UI test targets to support the refactored flow.
- Local validation passed for the touched project and app code paths.