### PR TITLE
Decouple category services from Realm-backed storage

### DIFF
--- a/.agents/memory-bank/activeContext.md
+++ b/.agents/memory-bank/activeContext.md
@@ -51,12 +51,14 @@ The primary focus is the Modernization of the Unified Search Subsystem (`Calibre
 - [x] 34. Fixed EnvironmentObject propagation crash in `LibraryInfoCategoryItemsView` and `LibraryInfoView` by explicitly injecting the `libraryInfoViewModel` environment object to `LibraryInfoBookListView`.
 - [x] 35. Refactored ServerView components (`AddModServerView`, `ServerDetailView`, `ServerOptionsDSReaderHelper`, `LibraryDetailView`) to MVVM using two view models (`ServerViewModel` and `LibraryViewModel`), completely decoupling `LibraryDetailView` from Realm.
 - [x] 36. Fixed `libraryRowBuilder` sync status UI in `ServerDetailView.swift` to display mutually exclusive status text instead of overlapping states.
+- [x] 37. Refactored `ReaderOptionsView.swift` to strictly enforce the MVVM pattern by delegating preferred formats, reader types, and font import/deletion state to `ReaderOptionsViewModel`.
 
 ## Active Tasks
 - [x] Decouple category views completely from RealmSwift.
 - [x] Decouple BookDetailView completely from RealmSwift.
 - [x] Refactor ServerView components to MVVM.
 - [x] Fix libraryRowBuilder sync status UI representation.
+- [x] Refactor ReaderOptionsView to MVVM and register project files.
 
 ## Active Constraints
 - **Do NOT** introduce CocoaPods or modify workspace files; the project relies entirely on Swift Package Manager.

--- a/.agents/memory-bank/activeContext.md
+++ b/.agents/memory-bank/activeContext.md
@@ -44,8 +44,13 @@ The primary focus is the Modernization of the Unified Search Subsystem (`Calibre
 - [x] 27. Decoupled `libraryStatuses` from `UnifiedSearchResult` by updating `UnifiedSearchService` to stream `SearchUpdate` value types and `UnifiedSearchViewModel` to publish statuses separately.
 - [x] 28. Refactored search criteria and UI preferences to `LibraryInfoView.ViewModel`, removing criteria properties from `UnifiedSearchViewModel` and passing `SearchCriteriaMergedKey` to `startSearch(key:)` explicitly.
 - [x] 29. Fixed the Combine bridge task leak in `publisher(for:)` by wrapping the subscription block inside `Deferred`.
+- [x] 30. Bypassed the autoUpdate check in category fetching inside `ModelData.syncLibrary(request:)` to ensure calibre library categories are synced and populated on startup/probes even when autoUpdate ("Available when Offline") is disabled.
+- [x] 31. Decoupled `LibraryInfoCategoryListView` and `LibraryInfoView` completely from `RealmSwift` by introducing `CategoryCacheSummary` value types and querying summaries via `CategoryCacheRepository` reactively inside the `LibraryInfoView.ViewModel`.
+- [x] 32. Decoupled `LibraryInfoCategoryItemsView` completely from `RealmSwift` by implementing cache invalidation in the repository layer and exposing `forceRefreshCategory` in the `UnifiedCategoryViewModel`.
+
+## Active Tasks
+- [x] Decouple category views completely from RealmSwift.
 
 ## Active Constraints
 - **Do NOT** introduce CocoaPods or modify workspace files; the project relies entirely on Swift Package Manager.
 - **Decoupling Goal:** Views should minimize direct dependency on `ModelData` for network operations; logic should reside in dedicated ViewModels.
-

--- a/.agents/memory-bank/activeContext.md
+++ b/.agents/memory-bank/activeContext.md
@@ -49,10 +49,12 @@ The primary focus is the Modernization of the Unified Search Subsystem (`Calibre
 - [x] 32. Decoupled `LibraryInfoCategoryItemsView` completely from `RealmSwift` by implementing cache invalidation in the repository layer and exposing `forceRefreshCategory` in the `UnifiedCategoryViewModel`.
 - [x] 33. Decoupled `BookDetailView` completely from `RealmSwift` by shifting Realm database queries and reactive observations to `BookDetailViewModel`.
 - [x] 34. Fixed EnvironmentObject propagation crash in `LibraryInfoCategoryItemsView` and `LibraryInfoView` by explicitly injecting the `libraryInfoViewModel` environment object to `LibraryInfoBookListView`.
+- [x] 35. Refactored ServerView components (`AddModServerView`, `ServerDetailView`, `ServerOptionsDSReaderHelper`, `LibraryDetailView`) to MVVM using two view models (`ServerViewModel` and `LibraryViewModel`), completely decoupling `LibraryDetailView` from Realm.
 
 ## Active Tasks
 - [x] Decouple category views completely from RealmSwift.
 - [x] Decouple BookDetailView completely from RealmSwift.
+- [x] Refactor ServerView components to MVVM.
 
 ## Active Constraints
 - **Do NOT** introduce CocoaPods or modify workspace files; the project relies entirely on Swift Package Manager.

--- a/.agents/memory-bank/activeContext.md
+++ b/.agents/memory-bank/activeContext.md
@@ -50,11 +50,13 @@ The primary focus is the Modernization of the Unified Search Subsystem (`Calibre
 - [x] 33. Decoupled `BookDetailView` completely from `RealmSwift` by shifting Realm database queries and reactive observations to `BookDetailViewModel`.
 - [x] 34. Fixed EnvironmentObject propagation crash in `LibraryInfoCategoryItemsView` and `LibraryInfoView` by explicitly injecting the `libraryInfoViewModel` environment object to `LibraryInfoBookListView`.
 - [x] 35. Refactored ServerView components (`AddModServerView`, `ServerDetailView`, `ServerOptionsDSReaderHelper`, `LibraryDetailView`) to MVVM using two view models (`ServerViewModel` and `LibraryViewModel`), completely decoupling `LibraryDetailView` from Realm.
+- [x] 36. Fixed `libraryRowBuilder` sync status UI in `ServerDetailView.swift` to display mutually exclusive status text instead of overlapping states.
 
 ## Active Tasks
 - [x] Decouple category views completely from RealmSwift.
 - [x] Decouple BookDetailView completely from RealmSwift.
 - [x] Refactor ServerView components to MVVM.
+- [x] Fix libraryRowBuilder sync status UI representation.
 
 ## Active Constraints
 - **Do NOT** introduce CocoaPods or modify workspace files; the project relies entirely on Swift Package Manager.

--- a/.agents/memory-bank/activeContext.md
+++ b/.agents/memory-bank/activeContext.md
@@ -47,9 +47,11 @@ The primary focus is the Modernization of the Unified Search Subsystem (`Calibre
 - [x] 30. Bypassed the autoUpdate check in category fetching inside `ModelData.syncLibrary(request:)` to ensure calibre library categories are synced and populated on startup/probes even when autoUpdate ("Available when Offline") is disabled.
 - [x] 31. Decoupled `LibraryInfoCategoryListView` and `LibraryInfoView` completely from `RealmSwift` by introducing `CategoryCacheSummary` value types and querying summaries via `CategoryCacheRepository` reactively inside the `LibraryInfoView.ViewModel`.
 - [x] 32. Decoupled `LibraryInfoCategoryItemsView` completely from `RealmSwift` by implementing cache invalidation in the repository layer and exposing `forceRefreshCategory` in the `UnifiedCategoryViewModel`.
+- [x] 33. Decoupled `BookDetailView` completely from `RealmSwift` by shifting Realm database queries and reactive observations to `BookDetailViewModel`.
 
 ## Active Tasks
 - [x] Decouple category views completely from RealmSwift.
+- [x] Decouple BookDetailView completely from RealmSwift.
 
 ## Active Constraints
 - **Do NOT** introduce CocoaPods or modify workspace files; the project relies entirely on Swift Package Manager.

--- a/.agents/memory-bank/activeContext.md
+++ b/.agents/memory-bank/activeContext.md
@@ -48,6 +48,7 @@ The primary focus is the Modernization of the Unified Search Subsystem (`Calibre
 - [x] 31. Decoupled `LibraryInfoCategoryListView` and `LibraryInfoView` completely from `RealmSwift` by introducing `CategoryCacheSummary` value types and querying summaries via `CategoryCacheRepository` reactively inside the `LibraryInfoView.ViewModel`.
 - [x] 32. Decoupled `LibraryInfoCategoryItemsView` completely from `RealmSwift` by implementing cache invalidation in the repository layer and exposing `forceRefreshCategory` in the `UnifiedCategoryViewModel`.
 - [x] 33. Decoupled `BookDetailView` completely from `RealmSwift` by shifting Realm database queries and reactive observations to `BookDetailViewModel`.
+- [x] 34. Fixed EnvironmentObject propagation crash in `LibraryInfoCategoryItemsView` and `LibraryInfoView` by explicitly injecting the `libraryInfoViewModel` environment object to `LibraryInfoBookListView`.
 
 ## Active Tasks
 - [x] Decouple category views completely from RealmSwift.

--- a/YetAnotherEBookReader.xcodeproj/project.pbxproj
+++ b/YetAnotherEBookReader.xcodeproj/project.pbxproj
@@ -579,9 +579,9 @@
 			isa = PBXGroup;
 			children = (
 				2A47581A27BE250600642AD1 /* AddModServerView.swift */,
+				2A47581827BA8C0200642AD1 /* LibraryDetailView.swift */,
 				2A47581627B9EF8400642AD1 /* ServerDetailView.swift */,
 				2AE26432274B8D4B00DC5806 /* ServerOptionsDSReaderHelper.swift */,
-				2A47581827BA8C0200642AD1 /* LibraryDetailView.swift */,
 			);
 			path = ServerView;
 			sourceTree = "<group>";

--- a/YetAnotherEBookReader.xcodeproj/project.pbxproj
+++ b/YetAnotherEBookReader.xcodeproj/project.pbxproj
@@ -203,6 +203,10 @@
 		E71F34D42FDBD7AB007AB0B1 /* UnifiedCategoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71F34D32FDBD7AB007AB0B1 /* UnifiedCategoryViewModel.swift */; };
 		E71F34D52FDBD7AB007AB0B1 /* UnifiedCategoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71F34D32FDBD7AB007AB0B1 /* UnifiedCategoryViewModel.swift */; };
 		E71F34D72FDBDA3F007AB0B1 /* UnifiedCategoryServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71F34D62FDBDA3F007AB0B1 /* UnifiedCategoryServiceTests.swift */; };
+		E71F34D92FDC5529007AB0B1 /* LibraryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71F34D82FDC5529007AB0B1 /* LibraryViewModel.swift */; };
+		E71F34DA2FDC5529007AB0B1 /* LibraryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71F34D82FDC5529007AB0B1 /* LibraryViewModel.swift */; };
+		E71F34DC2FDC555A007AB0B1 /* ServerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71F34DB2FDC555A007AB0B1 /* ServerViewModel.swift */; };
+		E71F34DD2FDC555A007AB0B1 /* ServerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71F34DB2FDC555A007AB0B1 /* ServerViewModel.swift */; };
 		E730405828E865550013BA01 /* YabrEBookReaderMetaSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = E730405728E865550013BA01 /* YabrEBookReaderMetaSource.swift */; };
 		E730405C28EBDAB50013BA01 /* BookAnnotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E730405B28EBDAB50013BA01 /* BookAnnotation.swift */; };
 		E732E3ED2A3F03350075D1AC /* BookDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7804CCD29D138980066BD43 /* BookDetailView.swift */; };
@@ -409,6 +413,8 @@
 		E71F34D02FDBD78E007AB0B1 /* UnifiedCategoryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedCategoryService.swift; sourceTree = "<group>"; };
 		E71F34D32FDBD7AB007AB0B1 /* UnifiedCategoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedCategoryViewModel.swift; sourceTree = "<group>"; };
 		E71F34D62FDBDA3F007AB0B1 /* UnifiedCategoryServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedCategoryServiceTests.swift; sourceTree = "<group>"; };
+		E71F34D82FDC5529007AB0B1 /* LibraryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryViewModel.swift; sourceTree = "<group>"; };
+		E71F34DB2FDC555A007AB0B1 /* ServerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerViewModel.swift; sourceTree = "<group>"; };
 		E730405728E865550013BA01 /* YabrEBookReaderMetaSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YabrEBookReaderMetaSource.swift; sourceTree = "<group>"; };
 		E730405B28EBDAB50013BA01 /* BookAnnotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookAnnotation.swift; sourceTree = "<group>"; };
 		E738C89E29160AA700A4AC6E /* CalibreBrowser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalibreBrowser.swift; sourceTree = "<group>"; };
@@ -582,6 +588,8 @@
 				2A47581827BA8C0200642AD1 /* LibraryDetailView.swift */,
 				2A47581627B9EF8400642AD1 /* ServerDetailView.swift */,
 				2AE26432274B8D4B00DC5806 /* ServerOptionsDSReaderHelper.swift */,
+				E71F34D82FDC5529007AB0B1 /* LibraryViewModel.swift */,
+				E71F34DB2FDC555A007AB0B1 /* ServerViewModel.swift */,
 			);
 			path = ServerView;
 			sourceTree = "<group>";
@@ -1129,6 +1137,7 @@
 				2AC3EC1C25BDBC10004A6633 /* YetAnotherEBookReaderApp.swift in Sources */,
 				2ABB913F261EC359004AA7C0 /* CalibreData.swift in Sources */,
 				2A890571260076780072B580 /* YabrPDFOptionView.swift in Sources */,
+				E71F34DC2FDC555A007AB0B1 /* ServerViewModel.swift in Sources */,
 				E7C777A628ED495900939D63 /* YabrPDFBookmarkList.swift in Sources */,
 				E738C89F29160AA700A4AC6E /* CalibreBrowser.swift in Sources */,
 				2ABB9157261F1A47004AA7C0 /* MainView.swift in Sources */,
@@ -1192,6 +1201,7 @@
 				2AAE409F26784D080058A501 /* LibraryBookListFilter.swift in Sources */,
 				2ABB9135261DE894004AA7C0 /* RecentShelfUI.swift in Sources */,
 				E7C777A328ED495900939D63 /* YabrPDFChapterListCell.swift in Sources */,
+				E71F34D92FDC5529007AB0B1 /* LibraryViewModel.swift in Sources */,
 				2ABB9154261F1A47004AA7C0 /* LibraryInfoView.swift in Sources */,
 				E7C777A728ED495900939D63 /* YabrPDFHighlightList.swift in Sources */,
 				E74729C329D52F5E007659A1 /* LibraryInfoBookListInfoView.swift in Sources */,
@@ -1277,6 +1287,7 @@
 				6E7B80E228FBA7AD008B075C /* YabrPDFReferenceList.swift in Sources */,
 				6E7B80E328FBA7AD008B075C /* YabrPDFReferenceListCell.swift in Sources */,
 				6E7B80E428FBA7AD008B075C /* YabrPDFTableViewController.swift in Sources */,
+				E71F34DD2FDC555A007AB0B1 /* ServerViewModel.swift in Sources */,
 				E70A25CA2F7BDC8D004F006E /* YabrReaderSettingsView.swift in Sources */,
 				6E7B80E528FBA7AD008B075C /* YabrPDFModel.swift in Sources */,
 				6E7B80E628FBA7AD008B075C /* YabrPDFView.swift in Sources */,
@@ -1340,6 +1351,7 @@
 				2ADCD80F26F4B96200FBAE11 /* SettingsView.swift in Sources */,
 				2ADCD81526F4B96200FBAE11 /* YabrData.swift in Sources */,
 				2ADCD81A26F4B96200FBAE11 /* MDictView.swift in Sources */,
+				E71F34DA2FDC5529007AB0B1 /* LibraryViewModel.swift in Sources */,
 				2ADCD81C26F4B96200FBAE11 /* BookPreference.swift in Sources */,
 				2ADCD81E26F4B96200FBAE11 /* SectionShelfUI.swift in Sources */,
 				2ADCD82326F4B96200FBAE11 /* ImageRequest.swift in Sources */,

--- a/YetAnotherEBookReader.xcodeproj/project.pbxproj
+++ b/YetAnotherEBookReader.xcodeproj/project.pbxproj
@@ -190,6 +190,19 @@
 		E71F34C02FDA9284007AB0B1 /* UnifiedSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71F34BE2FDA9284007AB0B1 /* UnifiedSearchService.swift */; };
 		E71F34C22FDA9290007AB0B1 /* UnifiedSearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71F34C12FDA9290007AB0B1 /* UnifiedSearchViewModel.swift */; };
 		E71F34C32FDA9290007AB0B1 /* UnifiedSearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71F34C12FDA9290007AB0B1 /* UnifiedSearchViewModel.swift */; };
+		E71F34C52FDBD766007AB0B1 /* CategoryModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71F34C42FDBD766007AB0B1 /* CategoryModels.swift */; };
+		E71F34C62FDBD766007AB0B1 /* CategoryModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71F34C42FDBD766007AB0B1 /* CategoryModels.swift */; };
+		E71F34C82FDBD76C007AB0B1 /* CategoryCacheRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71F34C72FDBD76C007AB0B1 /* CategoryCacheRepository.swift */; };
+		E71F34C92FDBD76C007AB0B1 /* CategoryCacheRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71F34C72FDBD76C007AB0B1 /* CategoryCacheRepository.swift */; };
+		E71F34CB2FDBD784007AB0B1 /* LibraryCategoryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71F34CA2FDBD784007AB0B1 /* LibraryCategoryService.swift */; };
+		E71F34CC2FDBD784007AB0B1 /* LibraryCategoryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71F34CA2FDBD784007AB0B1 /* LibraryCategoryService.swift */; };
+		E71F34CE2FDBD789007AB0B1 /* UnifiedCategoryMergeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71F34CD2FDBD789007AB0B1 /* UnifiedCategoryMergeService.swift */; };
+		E71F34CF2FDBD789007AB0B1 /* UnifiedCategoryMergeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71F34CD2FDBD789007AB0B1 /* UnifiedCategoryMergeService.swift */; };
+		E71F34D12FDBD78E007AB0B1 /* UnifiedCategoryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71F34D02FDBD78E007AB0B1 /* UnifiedCategoryService.swift */; };
+		E71F34D22FDBD78E007AB0B1 /* UnifiedCategoryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71F34D02FDBD78E007AB0B1 /* UnifiedCategoryService.swift */; };
+		E71F34D42FDBD7AB007AB0B1 /* UnifiedCategoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71F34D32FDBD7AB007AB0B1 /* UnifiedCategoryViewModel.swift */; };
+		E71F34D52FDBD7AB007AB0B1 /* UnifiedCategoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71F34D32FDBD7AB007AB0B1 /* UnifiedCategoryViewModel.swift */; };
+		E71F34D72FDBDA3F007AB0B1 /* UnifiedCategoryServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71F34D62FDBDA3F007AB0B1 /* UnifiedCategoryServiceTests.swift */; };
 		E730405828E865550013BA01 /* YabrEBookReaderMetaSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = E730405728E865550013BA01 /* YabrEBookReaderMetaSource.swift */; };
 		E730405C28EBDAB50013BA01 /* BookAnnotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E730405B28EBDAB50013BA01 /* BookAnnotation.swift */; };
 		E732E3ED2A3F03350075D1AC /* BookDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7804CCD29D138980066BD43 /* BookDetailView.swift */; };
@@ -389,6 +402,13 @@
 		E71F34BB2FDA926F007AB0B1 /* LibrarySearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibrarySearchService.swift; sourceTree = "<group>"; };
 		E71F34BE2FDA9284007AB0B1 /* UnifiedSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedSearchService.swift; sourceTree = "<group>"; };
 		E71F34C12FDA9290007AB0B1 /* UnifiedSearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedSearchViewModel.swift; sourceTree = "<group>"; };
+		E71F34C42FDBD766007AB0B1 /* CategoryModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryModels.swift; sourceTree = "<group>"; };
+		E71F34C72FDBD76C007AB0B1 /* CategoryCacheRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryCacheRepository.swift; sourceTree = "<group>"; };
+		E71F34CA2FDBD784007AB0B1 /* LibraryCategoryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryCategoryService.swift; sourceTree = "<group>"; };
+		E71F34CD2FDBD789007AB0B1 /* UnifiedCategoryMergeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedCategoryMergeService.swift; sourceTree = "<group>"; };
+		E71F34D02FDBD78E007AB0B1 /* UnifiedCategoryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedCategoryService.swift; sourceTree = "<group>"; };
+		E71F34D32FDBD7AB007AB0B1 /* UnifiedCategoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedCategoryViewModel.swift; sourceTree = "<group>"; };
+		E71F34D62FDBDA3F007AB0B1 /* UnifiedCategoryServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedCategoryServiceTests.swift; sourceTree = "<group>"; };
 		E730405728E865550013BA01 /* YabrEBookReaderMetaSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YabrEBookReaderMetaSource.swift; sourceTree = "<group>"; };
 		E730405B28EBDAB50013BA01 /* BookAnnotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookAnnotation.swift; sourceTree = "<group>"; };
 		E738C89E29160AA700A4AC6E /* CalibreBrowser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalibreBrowser.swift; sourceTree = "<group>"; };
@@ -629,6 +649,7 @@
 				E74729C229D52F5E007659A1 /* LibraryInfoBookListInfoView.swift */,
 				E74729C429D54DB2007659A1 /* LibraryInfoViewModel.swift */,
 				E71F34C12FDA9290007AB0B1 /* UnifiedSearchViewModel.swift */,
+				E71F34D32FDBD7AB007AB0B1 /* UnifiedCategoryViewModel.swift */,
 			);
 			path = LibraryInfoView;
 			sourceTree = "<group>";
@@ -723,6 +744,7 @@
 				E71F34AE2FD9070B007AB0B1 /* UnifiedSearchMergeServiceTests.swift */,
 				E71F34B72FD9193C007AB0B1 /* UnifiedSearchServiceTests.swift */,
 				E71F34B92FDA51BE007AB0B1 /* UnifiedSearchIntegrationTests.swift */,
+				E71F34D62FDBDA3F007AB0B1 /* UnifiedCategoryServiceTests.swift */,
 			);
 			path = YetAnotherEBookReaderTests;
 			sourceTree = "<group>";
@@ -760,6 +782,7 @@
 				E71F34A62FD906F1007AB0B1 /* Utils */,
 				E71F34A72FD906F3007AB0B1 /* Services */,
 				E71F34B02FD918FD007AB0B1 /* UnifiedSearch */,
+				E71F34C42FDBD766007AB0B1 /* CategoryModels.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -792,6 +815,7 @@
 			isa = PBXGroup;
 			children = (
 				E71F349A2FD8FDCB007AB0B1 /* SearchCacheRepository.swift */,
+				E71F34C72FDBD76C007AB0B1 /* CategoryCacheRepository.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -818,6 +842,9 @@
 				E71F34AB2FD90701007AB0B1 /* UnifiedSearchMergeService.swift */,
 				E71F34BB2FDA926F007AB0B1 /* LibrarySearchService.swift */,
 				E71F34BE2FDA9284007AB0B1 /* UnifiedSearchService.swift */,
+				E71F34CA2FDBD784007AB0B1 /* LibraryCategoryService.swift */,
+				E71F34CD2FDBD789007AB0B1 /* UnifiedCategoryMergeService.swift */,
+				E71F34D02FDBD78E007AB0B1 /* UnifiedCategoryService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -1059,6 +1086,7 @@
 			files = (
 				E792C7EB2F84990E0015E020 /* ReadingSessionManager.swift in Sources */,
 				E782836628EEA5BA0011438D /* YabrPDFTableViewController.swift in Sources */,
+				E71F34C82FDBD76C007AB0B1 /* CategoryCacheRepository.swift in Sources */,
 				E7C7779528ED324300939D63 /* YabrPDFAnnotationPageVC.swift in Sources */,
 				2A1A4BF62616CCED00E95ED5 /* SwiftUI_Ad_Banner.swift in Sources */,
 				2A4787A127154E39009C8770 /* FontImportPicker.swift in Sources */,
@@ -1071,6 +1099,7 @@
 				E7C777AB28ED4A5500939D63 /* YabrPDFBookmarkListCell.swift in Sources */,
 				2A78A6322717D96000A81E53 /* BookImportPicker.swift in Sources */,
 				E71F34AA2FD906F9007AB0B1 /* MergeHead.swift in Sources */,
+				E71F34D52FDBD7AB007AB0B1 /* UnifiedCategoryViewModel.swift in Sources */,
 				2A0A78A126EB2AC300F3C753 /* PDFPageWithBackground.swift in Sources */,
 				2A0EBA86267893740080BF5B /* Downloader.swift in Sources */,
 				E71F34882FD3B23D007AB0B1 /* BookDetailSubviews.swift in Sources */,
@@ -1093,6 +1122,7 @@
 				E7804CCC29C0220D0066BD43 /* CalibreSearchCache.swift in Sources */,
 				2AD38F8726D637B70053D01D /* ReadingPositionDetailView.swift in Sources */,
 				E792835528F7DFD100EE2FC7 /* YabrPDFNavigationPageVC.swift in Sources */,
+				E71F34CF2FDBD789007AB0B1 /* UnifiedCategoryMergeService.swift in Sources */,
 				2AAB2998271415E10080B0CB /* AppInfoView.swift in Sources */,
 				2ABB9158261F1A47004AA7C0 /* EpubFolioReaderContainer.swift in Sources */,
 				E70A25CB2F7BDC8D004F006E /* YabrReaderSettingsView.swift in Sources */,
@@ -1117,10 +1147,12 @@
 				E71F348B2FD416AA007AB0B1 /* ActivityListViewModel.swift in Sources */,
 				E71F34BF2FDA9284007AB0B1 /* UnifiedSearchService.swift in Sources */,
 				E792835928F835FA00EE2FC7 /* YabrPDFThumbnailList.swift in Sources */,
+				E71F34CC2FDBD784007AB0B1 /* LibraryCategoryService.swift in Sources */,
 				2AE26433274B8D4B00DC5806 /* ServerOptionsDSReaderHelper.swift in Sources */,
 				2ABB912A261DE894004AA7C0 /* SectionShelfController.swift in Sources */,
 				2AA07E9326DB4ADD008CE451 /* BookPreviewView.swift in Sources */,
 				2AF53FD32675FA89006E92E0 /* ReaderOptionsView.swift in Sources */,
+				E71F34D12FDBD78E007AB0B1 /* UnifiedCategoryService.swift in Sources */,
 				2ABB9156261F1A47004AA7C0 /* YabrEBookReader.swift in Sources */,
 				2A107D422661CFBB007DCA20 /* YabrReadiumEPUBViewController.swift in Sources */,
 				2ACE265926A921230037FCB4 /* RealmModel.swift in Sources */,
@@ -1130,6 +1162,7 @@
 				2A6FF9E9270D5DC000811C50 /* MDictViewUIVC.swift in Sources */,
 				2A270B25272F7E07006552A3 /* ActivityList.swift in Sources */,
 				E7DFE3F1297A749800C60E7B /* ReaderOptionsFontHelpView.swift in Sources */,
+				E71F34C62FDBD766007AB0B1 /* CategoryModels.swift in Sources */,
 				E7C777A028ED495900939D63 /* YabrPDFReferenceList.swift in Sources */,
 				2AF53FD12675F680006E92E0 /* SettingsView.swift in Sources */,
 				E71F349E2FD8FDD0007AB0B1 /* RealmSearchCacheStore.swift in Sources */,
@@ -1178,6 +1211,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E71F34D72FDBDA3F007AB0B1 /* UnifiedCategoryServiceTests.swift in Sources */,
 				E71F34AF2FD9070B007AB0B1 /* UnifiedSearchMergeServiceTests.swift in Sources */,
 				E71F34862FD3AED3007AB0B1 /* BookDetailViewModelTests.swift in Sources */,
 				E71F34B82FD9193C007AB0B1 /* UnifiedSearchServiceTests.swift in Sources */,
@@ -1200,6 +1234,7 @@
 			files = (
 				E792C7EC2F84990E0015E020 /* ReadingSessionManager.swift in Sources */,
 				E7D315102BE5F8AF00A5B50A /* DictWebView.swift in Sources */,
+				E71F34C92FDBD76C007AB0B1 /* CategoryCacheRepository.swift in Sources */,
 				E7D315112BE5F8AF00A5B50A /* EncycloView.swift in Sources */,
 				E7D315122BE5F8AF00A5B50A /* DictTabBarController.swift in Sources */,
 				E7D315132BE5F8AF00A5B50A /* MDictViewEdit.swift in Sources */,
@@ -1212,6 +1247,7 @@
 				E732E3EF2A3F03350075D1AC /* LibraryInfoCategoryListView.swift in Sources */,
 				E732E3F02A3F03350075D1AC /* LibraryInfoCategoryItemsView.swift in Sources */,
 				E71F34A92FD906F9007AB0B1 /* MergeHead.swift in Sources */,
+				E71F34D42FDBD7AB007AB0B1 /* UnifiedCategoryViewModel.swift in Sources */,
 				E732E3F12A3F03350075D1AC /* LibraryInfoBookListInfoView.swift in Sources */,
 				E732E3F22A3F03350075D1AC /* LibraryInfoViewModel.swift in Sources */,
 				E71F34892FD3B23D007AB0B1 /* BookDetailSubviews.swift in Sources */,
@@ -1234,6 +1270,7 @@
 				6E7B80DC28FBA7AD008B075C /* YabrPDFBookmarkList.swift in Sources */,
 				6E7B80DD28FBA7AD008B075C /* YabrPDFBookmarkListCell.swift in Sources */,
 				6E7B80DE28FBA7AD008B075C /* YabrPDFChapterList.swift in Sources */,
+				E71F34CE2FDBD789007AB0B1 /* UnifiedCategoryMergeService.swift in Sources */,
 				6E7B80DF28FBA7AD008B075C /* YabrPDFChapterListCell.swift in Sources */,
 				6E7B80E028FBA7AD008B075C /* YabrPDFHighlightList.swift in Sources */,
 				6E7B80E128FBA7AD008B075C /* YabrPDFHighlightListCell.swift in Sources */,
@@ -1258,10 +1295,12 @@
 				E71F348C2FD416AA007AB0B1 /* ActivityListViewModel.swift in Sources */,
 				E71F34C02FDA9284007AB0B1 /* UnifiedSearchService.swift in Sources */,
 				6E7B80FA28FBA7AD008B075C /* ServerOptionsDSReaderHelper.swift in Sources */,
+				E71F34CB2FDBD784007AB0B1 /* LibraryCategoryService.swift in Sources */,
 				6E7B80FB28FBA7AD008B075C /* SupportCalibreIntroView.swift in Sources */,
 				6E7B80FC28FBA7AD008B075C /* LibraryDetailView.swift in Sources */,
 				6E7B80FD28FBA7AD008B075C /* SupportInfoView.swift in Sources */,
 				6E7B80FF28FBA7AD008B075C /* MDictViewUIVC.swift in Sources */,
+				E71F34D22FDBD78E007AB0B1 /* UnifiedCategoryService.swift in Sources */,
 				6E7B810028FBA7AD008B075C /* CalibreDateParser.swift in Sources */,
 				6E7B810228FBA7AD008B075C /* BookAnnotation.swift in Sources */,
 				E70A25CE2F7D1A5D004F006E /* YabrReaderNavigationViewModel.swift in Sources */,
@@ -1271,6 +1310,7 @@
 				2ADCD7E026F4B96200FBAE11 /* PDFPageWithBackground.swift in Sources */,
 				2ADCD7E126F4B96200FBAE11 /* Downloader.swift in Sources */,
 				2ADCD7E426F4B96200FBAE11 /* WebViewUIVC.swift in Sources */,
+				E71F34C52FDBD766007AB0B1 /* CategoryModels.swift in Sources */,
 				2ADCD7E626F4B96200FBAE11 /* Utils.swift in Sources */,
 				2ADCD7E726F4B96200FBAE11 /* YabrPDFViewController.swift in Sources */,
 				E71F349F2FD8FDD0007AB0B1 /* RealmSearchCacheStore.swift in Sources */,

--- a/YetAnotherEBookReader.xcodeproj/project.pbxproj
+++ b/YetAnotherEBookReader.xcodeproj/project.pbxproj
@@ -207,6 +207,9 @@
 		E71F34DA2FDC5529007AB0B1 /* LibraryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71F34D82FDC5529007AB0B1 /* LibraryViewModel.swift */; };
 		E71F34DC2FDC555A007AB0B1 /* ServerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71F34DB2FDC555A007AB0B1 /* ServerViewModel.swift */; };
 		E71F34DD2FDC555A007AB0B1 /* ServerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71F34DB2FDC555A007AB0B1 /* ServerViewModel.swift */; };
+		E71F34DF2FDCF7DC007AB0B1 /* ReaderOptionsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71F34DE2FDCF7DC007AB0B1 /* ReaderOptionsViewModel.swift */; };
+		E71F34E02FDCF7DC007AB0B1 /* ReaderOptionsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71F34DE2FDCF7DC007AB0B1 /* ReaderOptionsViewModel.swift */; };
+		E71F34E22FDCF834007AB0B1 /* ReaderOptionsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71F34E12FDCF834007AB0B1 /* ReaderOptionsViewModelTests.swift */; };
 		E730405828E865550013BA01 /* YabrEBookReaderMetaSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = E730405728E865550013BA01 /* YabrEBookReaderMetaSource.swift */; };
 		E730405C28EBDAB50013BA01 /* BookAnnotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E730405B28EBDAB50013BA01 /* BookAnnotation.swift */; };
 		E732E3ED2A3F03350075D1AC /* BookDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7804CCD29D138980066BD43 /* BookDetailView.swift */; };
@@ -415,6 +418,8 @@
 		E71F34D62FDBDA3F007AB0B1 /* UnifiedCategoryServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedCategoryServiceTests.swift; sourceTree = "<group>"; };
 		E71F34D82FDC5529007AB0B1 /* LibraryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryViewModel.swift; sourceTree = "<group>"; };
 		E71F34DB2FDC555A007AB0B1 /* ServerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerViewModel.swift; sourceTree = "<group>"; };
+		E71F34DE2FDCF7DC007AB0B1 /* ReaderOptionsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderOptionsViewModel.swift; sourceTree = "<group>"; };
+		E71F34E12FDCF834007AB0B1 /* ReaderOptionsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderOptionsViewModelTests.swift; sourceTree = "<group>"; };
 		E730405728E865550013BA01 /* YabrEBookReaderMetaSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YabrEBookReaderMetaSource.swift; sourceTree = "<group>"; };
 		E730405B28EBDAB50013BA01 /* BookAnnotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookAnnotation.swift; sourceTree = "<group>"; };
 		E738C89E29160AA700A4AC6E /* CalibreBrowser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalibreBrowser.swift; sourceTree = "<group>"; };
@@ -564,6 +569,7 @@
 				2AF8589C2712825400FA87AD /* ReaderOptionsFormatHelpView.swift */,
 				E7DFE3EE297A729900C60E7B /* ReaderOptionsReaderHelpView.swift */,
 				E7DFE3F0297A749800C60E7B /* ReaderOptionsFontHelpView.swift */,
+				E71F34DE2FDCF7DC007AB0B1 /* ReaderOptionsViewModel.swift */,
 			);
 			path = ReaderOptions;
 			sourceTree = "<group>";
@@ -753,6 +759,7 @@
 				E71F34B72FD9193C007AB0B1 /* UnifiedSearchServiceTests.swift */,
 				E71F34B92FDA51BE007AB0B1 /* UnifiedSearchIntegrationTests.swift */,
 				E71F34D62FDBDA3F007AB0B1 /* UnifiedCategoryServiceTests.swift */,
+				E71F34E12FDCF834007AB0B1 /* ReaderOptionsViewModelTests.swift */,
 			);
 			path = YetAnotherEBookReaderTests;
 			sourceTree = "<group>";
@@ -1212,6 +1219,7 @@
 				2AC340D32647A23600A477ED /* DSReaderHelperConnector.swift in Sources */,
 				E7AD2143293720AC00736FEF /* ShelfDataManager.swift in Sources */,
 				E75A97CD2A68C79D000F4292 /* YabrPDFSharingProvider.swift in Sources */,
+				E71F34E02FDCF7DC007AB0B1 /* ReaderOptionsViewModel.swift in Sources */,
 				2AF6FE0A2701B205002BA27E /* YabrReadiumPDFViewController.swift in Sources */,
 				2AF6FE0C2701D0F7002BA27E /* YabrReadiumReaderViewController.swift in Sources */,
 			);
@@ -1221,6 +1229,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E71F34E22FDCF834007AB0B1 /* ReaderOptionsViewModelTests.swift in Sources */,
 				E71F34D72FDBDA3F007AB0B1 /* UnifiedCategoryServiceTests.swift in Sources */,
 				E71F34AF2FD9070B007AB0B1 /* UnifiedSearchMergeServiceTests.swift in Sources */,
 				E71F34862FD3AED3007AB0B1 /* BookDetailViewModelTests.swift in Sources */,
@@ -1362,6 +1371,7 @@
 				2ADCD82F26F4B96200FBAE11 /* RecentShelfUI.swift in Sources */,
 				2ADCD83126F4B96200FBAE11 /* LibraryInfoView.swift in Sources */,
 				2ADCD83226F4B96200FBAE11 /* CalibreServerService.swift in Sources */,
+				E71F34DF2FDCF7DC007AB0B1 /* ReaderOptionsViewModel.swift in Sources */,
 				2ADCD83526F4B96200FBAE11 /* Constants.swift in Sources */,
 				2ADCD83626F4B96200FBAE11 /* DSReaderHelperConnector.swift in Sources */,
 			);

--- a/YetAnotherEBookReader/Models/CalibreBrowser/CalibreBrowser.swift
+++ b/YetAnotherEBookReader/Models/CalibreBrowser/CalibreBrowser.swift
@@ -174,6 +174,9 @@ class CalibreLibrarySearchManager: ObservableObject {
 
     private let searchRuntimeLock = NSRecursiveLock()
     private(set) var unifiedSearchService: UnifiedSearchService!
+    private(set) var libraryCategoryService: LibraryCategoryService!
+    private(set) var unifiedCategoryService: UnifiedCategoryService!
+    private(set) var categoryCacheRepository: CategoryCacheRepository!
     
     private var cacheCategoryLibraryObjects: [CalibreLibraryCategoryKey: CalibreLibraryCategoryObject] = [:]
     private var cacheCategoryUnifiedObjects: [CalibreUnifiedCategoryKey: CalibreUnifiedCategoryObject] = [:]
@@ -210,10 +213,19 @@ class CalibreLibrarySearchManager: ObservableObject {
         self.cacheRealmConf = modelData.realmConf
         
         let cacheRepository = RealmSearchCacheStore(config: modelData.realmConf, modelData: modelData)
+        self.categoryCacheRepository = cacheRepository
         let librarySearch = LibrarySearchService(service: service, repository: cacheRepository)
         self.unifiedSearchService = UnifiedSearchService(
             repository: cacheRepository,
             librarySearchService: librarySearch,
+            libraryProvider: modelData
+        )
+        self.libraryCategoryService = LibraryCategoryService(
+            service: service,
+            repository: cacheRepository
+        )
+        self.unifiedCategoryService = UnifiedCategoryService(
+            repository: cacheRepository,
             libraryProvider: modelData
         )
         
@@ -243,10 +255,6 @@ class CalibreLibrarySearchManager: ObservableObject {
             registerSearchRefreshReceiver()
             registerSearchRequestReceiver()
             registerMetadataRequestReceiver()
-            
-
-            registerCategoryRefreshReceiver()
-            registerCategoryMergeReceiver()
             
             registerLibraryUpdateReceiver()
         }
@@ -311,60 +319,6 @@ class CalibreLibrarySearchManager: ObservableObject {
         
 
         
-        cacheRealm.objects(CalibreLibraryCategoryObject.self).forEach { cacheObj in
-            let categoryKey = CalibreLibraryCategoryKey(libraryId: cacheObj.libraryId, categoryName: cacheObj.categoryName)
-            
-            cacheCategoryLibraryObjects[categoryKey] = cacheObj
-            
-            registerCacheCategoryLibraryChangeReceiver(cacheObj: cacheObj)
-        }
-        
-        try! cacheRealm.write {
-            cacheRealm.delete(
-                cacheRealm.objects(CalibreUnifiedCategoryObject.self)
-                    .where({ $0.categoryName == "" })
-            )
-        }
-        
-        cacheRealm.objects(CalibreUnifiedCategoryObject.self).changesetPublisher
-            .receive(on: cacheRealmQueue)
-            .sink { [self] changes in
-                switch changes {
-                case .initial(let result):
-                    result.forEach { cacheObj in
-                        cacheCategoryUnifiedObjects[cacheObj.key] = cacheObj
-                        
-                        registerCacheCategoryUnifiedChangeReceiver(cacheObj: cacheObj)
-                        
-                        if cacheObj.itemsCount == 0,
-                           cacheObj.totalNumber < 999 {
-                            refreshUnifiedCategoryResult(cacheObj.key)
-                        }
-                    }
-                case .update(let result, deletions: _, insertions: let insertions, modifications: _):
-                    insertions.forEach {
-                        let cacheObj = result[$0]
-                        
-                        cacheCategoryUnifiedObjects[cacheObj.key] = cacheObj
-                        
-                        registerCacheCategoryUnifiedChangeReceiver(cacheObj: cacheObj)
-                        
-                        if cacheObj.itemsCount == 0,
-                           cacheObj.totalNumber < 999 {
-                            refreshUnifiedCategoryResult(cacheObj.key)
-                        }
-                    }
-                case .error(_):
-                    break
-                }
-            }
-            .store(in: &cancellables)
-        
-//        cacheRealm.objects(CalibreUnifiedCategoryObject.self).forEach { cacheObj in
-//            cacheCategoryUnifiedObjects[cacheObj.categoryName] = cacheObj
-//
-//            registerCacheCategoryUnifiedChangeReceiver(cacheObj: cacheObj)
-//        }
     }
     
     func initCacheSearchObject(searchKey: LibrarySearchKey) -> CalibreLibrarySearchObject {
@@ -410,23 +364,7 @@ class CalibreLibrarySearchManager: ObservableObject {
     
 
     
-    private func initCacheLibraryCategoryObject(categoryKey: CalibreLibraryCategoryKey) -> CalibreLibraryCategoryObject {
-        let cacheObj = CalibreLibraryCategoryObject()
-        
-        cacheObj.libraryId = categoryKey.libraryId
-        cacheObj.categoryName = categoryKey.categoryName
-        cacheObj.generation = .distantPast
-        
-        try! cacheRealm.write {
-            cacheRealm.add(cacheObj)
-        }
-        
-        cacheCategoryLibraryObjects[categoryKey] = cacheObj
-        
-        registerCacheCategoryLibraryChangeReceiver(cacheObj: cacheObj)
-        
-        return cacheObj
-    }
+
     
     func registerCacheSearchValueChangeReceiver(librarySearchKey: LibrarySearchKey, cacheObj: CalibreLibrarySearchObject, sourceObj: CalibreLibrarySearchValueObject) {
         sourceObj.bookIds.changesetPublisher
@@ -551,55 +489,7 @@ class CalibreLibrarySearchManager: ObservableObject {
     
 
     
-    func registerCacheCategoryLibraryChangeReceiver(cacheObj: CalibreLibraryCategoryObject) {
-        cacheObj.items.changesetPublisher
-            .subscribe(on: cacheRealmQueue)
-            .collect(.byTime(cacheRealmQueue, .seconds(2)))
-            .sink { changesList in
-                var initialCount = 0
-                var updateCount = 0
-                changesList.forEach { changes in
-                    switch changes {
-                    case .error(_):
-                        break
-                    case .initial(_):
-                        initialCount += cacheObj.items.count
-                        break
-                    case .update(_, deletions: let deletions, insertions: let insertions, modifications: let modifications):
-                        print("\(#function) \(cacheObj.libraryId) \(cacheObj.categoryName) deletion count=\(deletions.count)")
-                        print("\(#function) \(cacheObj.libraryId) \(cacheObj.categoryName) insertions count=\(insertions.count)")
-                        
-                        updateCount += deletions.count + insertions.count + modifications.count
-                    }
-                }
-                
-                if updateCount > 0 {
-                    self.categoryMergerHandlerSubject.send(.init(categoryName: cacheObj.categoryName, search: ""))
-                }
-                else if initialCount > 0 {
-                    self.categoryMergerRequestSubject.send(.init(categoryName: cacheObj.categoryName, search: ""))
-                }
-            }
-            .store(in: &cancellables)
-    }
-    
-    func registerCacheCategoryUnifiedChangeReceiver(cacheObj: CalibreUnifiedCategoryObject) {
-        cacheObj.items.changesetPublisher
-            .subscribe(on: cacheRealmQueue)
-            .sink { changes in
-                switch changes {
-                case .error(_):
-                    break
-                case .initial(_):
-                    break
-                case .update(_, deletions: let deletions, insertions: let insertions, modifications: _):
-                    print("\(#function) \(cacheObj.categoryName) deletion count=\(deletions.count)")
-                    print("\(#function) \(cacheObj.categoryName) insertions count=\(insertions.count)")
-                    break
-                }
-            }
-            .store(in: &cancellables)
-    }
+
     
     func registerSearchRefreshReceiver() {
         searchRefreshSubject.receive(on: cacheRealmQueue)
@@ -870,213 +760,7 @@ class CalibreLibrarySearchManager: ObservableObject {
             .store(in: &cancellables)
     }
     
-    func registerCategoryRefreshReceiver() {
-        categoryRequestSubject
-            .receive(on: cacheRealmQueue)
-            .flatMap { request -> AnyPublisher<LibraryCategoryList, Never> in
-                var justRequest = request
-                justRequest.retries = 0
-                
-                let just = Just(justRequest).setFailureType(to: Never.self).eraseToAnyPublisher()
-                
-                guard let serverUrl = self.service.getServerUrlByReachability(server: request.library.server)
-                else { return just }
-                
-                if let object = self.cacheCategoryLibraryObjects[.init(libraryId: request.library.id, categoryName: request.category.name)] {
-                    guard object.generation < request.library.lastModified
-                    else {
-                        return just
-                    }
-                }
-                
-                var urlComponents = URLComponents(string: request.category.url)
-                urlComponents?.queryItems = [
-                    URLQueryItem(name: "num", value: request.num.description),
-                    URLQueryItem(name: "offset", value: request.items.count.description)
-                ]
-                guard let url = urlComponents?.url(relativeTo: serverUrl)
-                else { return just }
-                
-                return self.service.urlSession(server: request.library.server, qos: .background).dataTaskPublisher(for: url)
-                    .map {
-                        $0.data
-                    }
-                    .decode(type: LibraryCategoryListResult.self, decoder: JSONDecoder())
-                    .map { result -> LibraryCategoryList in
-                        var request = request
-                        request.result = result
-                        return request
-                    }
-                    .replaceError(with: request)
-                    .eraseToAnyPublisher()
-            }
-            .receive(on: cacheRealmQueue)
-            .sink { [self] categoryList in
-                let categoryKey = CalibreLibraryCategoryKey(libraryId: categoryList.library.id, categoryName: categoryList.category.name)
-                
-                
-                // retry request
-                guard let result = categoryList.result else {
-                    if categoryList.retries > 0 {
-                        var categoryList = categoryList
-                        categoryList.retries -= 1
-                        cacheWorkerQueue.asyncAfter(deadline: .now() + 60.0) {
-                            self.categoryRequestSubject.send(categoryList)
-                        }
-                    }
-                    
-                    return
-                }
-                
-                if let cacheObj = cacheCategoryLibraryObjects[categoryKey] {
-                    guard result.total_num != cacheObj.items.count ||
-                        categoryList.library.lastModified > cacheObj.generation
-                    else {
-                        print("\(#function) skipping update for \(categoryKey)")
-                        return
-                    }
-                }
-                
-                
-                var categoryList = categoryList
-                
-                try! cacheRealm.write({
-                    result.items.forEach { item in
-                        let itemObj = cacheRealm
-                            .objects(CalibreLibraryCategoryItemObject.self)
-                            .where({ $0.url == item.url })
-                            .first ?? CalibreLibraryCategoryItemObject()
-                        
-                        if itemObj.realm == nil {
-                            itemObj.name = item.name
-                            itemObj.averageRating = item.average_rating
-                            itemObj.count = item.count
-                            itemObj.url = item.url
-                            cacheRealm.add(itemObj)
-                        } else {
-                            if itemObj.name != item.name {
-                                itemObj.name = item.name
-                            }
-                            if itemObj.averageRating != item.average_rating {
-                                itemObj.averageRating = item.average_rating
-                            }
-                            if itemObj.count != item.count {
-                                itemObj.count = item.count
-                            }
-                        }
-                        
-                        categoryList.items.append(itemObj)
-                    }
-                })
-                
-                if categoryList.items.count < result.total_num {
-                    // request more items if total_num is not reached
-                    categoryList.retries = 9
-                    categoryList.num = min(result.total_num - categoryList.items.count, 10000)
-                    categoryRequestSubject.send(categoryList)
-                } else {
-                    let cacheObj = cacheCategoryLibraryObjects[categoryKey] ?? initCacheLibraryCategoryObject(categoryKey: categoryKey)
-                    
-                    try? cacheRealm.write {
-                        cacheObj.items.removeAll()
-                        cacheObj.items.append(objectsIn: categoryList.items)
-                        cacheObj.generation = categoryList.library.lastModified
-                        cacheObj.totalNumber = result.total_num
-                    }
-                }
-            }
-            .store(in: &cancellables)
-    }
-    
-    fileprivate func registerCategoryMergeReceiver() {
-        self.categoryMergerRequestSubject
-            .collect(.byTime(RunLoop.main, .seconds(1)))
-            .sink { categoryKeys in
-                Set(categoryKeys).forEach {
-                    self.categoryMergerHandlerSubject.send($0)
-                }
-            }
-            .store(in: &cancellables)
-        
-        self.categoryMergerHandlerSubject.receive(on: cacheRealmQueue)
-            .map { categoryKey -> (CalibreUnifiedCategoryKey, [String: [CalibreLibraryCategoryItemObject]]) in
-                let nameItems = self.cacheCategoryLibraryObjects.filter {
-                    $0.key.categoryName == categoryKey.categoryName
-                }.filter {
-                    guard let library = self.modelData.calibreLibraries[$0.key.libraryId],
-                          library.hidden == false,
-                          library.server.removed == false
-                    else {
-                        return false
-                    }
-                    
-                    return true
-                }.reduce(into: [String: [CalibreLibraryCategoryItemObject]]()) { partialResult, libraryCategoryEntry in
-                    
-                    libraryCategoryEntry.value.items
-                        .filter({
-                            categoryKey.search.isEmpty
-                            ||
-                            $0.name.localizedCaseInsensitiveContains(categoryKey.search)
-                        })
-                        .forEach { categoryItem in
-                        
-                        if partialResult[categoryItem.name] == nil {
-                            partialResult[categoryItem.name] = [categoryItem]
-                        } else {
-                            partialResult[categoryItem.name]?.append(categoryItem)
-                        }
-                    }
-                }
-                
-                return (categoryKey, nameItems)
-            }
-            .sink { categoryKey, nameItems in
-                let cacheObj = self.retrieveUnifiedCategoryObject(categoryKey.categoryName, categoryKey.search, self.cacheRealm.objects(CalibreUnifiedCategoryObject.self))
-                
-                try! self.cacheRealm.write {
-                    if cacheObj.realm == nil {
-                        self.cacheRealm.add(cacheObj)
-                    } else {
-                        cacheObj.items.removeAll()
-                        cacheObj.itemsCount = 0
-                        cacheObj.totalNumber = 0
-                    }
-                    
-                    guard nameItems.count < 1000
-                    else {
-                        nameItems.forEach {
-                            cacheObj.totalNumber += $0.value.reduce(0, { partialResult, itemObj in
-                                partialResult + itemObj.count
-                            })
-                        }
-                        cacheObj.itemsCount = nameItems.count
-                        
-                        return
-                    }
-                    
-                    nameItems
-                        .sorted { $0.key < $1.key }
-                        .forEach { nameItemEntry in
-                            let unifiedItemObj = self.getOrCreateUnifiedCategoryItem(categoryName: categoryKey.categoryName, name: nameItemEntry.key)
-                            
-                            unifiedItemObj.items.removeAll()
-                            unifiedItemObj.items.insert(objectsIn: nameItemEntry.value)
-                            
-                            let stats = unifiedItemObj.items.reduce((0, 0.0)) { partialResult, itemObj in
-                                (partialResult.0 + itemObj.count, partialResult.1 + itemObj.averageRating * Double(itemObj.count))
-                            }
-                            unifiedItemObj.count = stats.0
-                            unifiedItemObj.averageRating = stats.1 / Double(stats.0)
-                            
-                            cacheObj.items.append(unifiedItemObj)
-                            cacheObj.itemsCount += 1
-                            cacheObj.totalNumber += stats.0
-                        }
-                }
-            }
-            .store(in: &cancellables)
-    }
+
     
     func registerLibraryUpdateReceiver() {
         return;
@@ -1195,22 +879,7 @@ class CalibreLibrarySearchManager: ObservableObject {
         }
     }
     
-    func getOrCreateUnifiedCategoryItem(categoryName: String, name: String) -> CalibreUnifiedCategoryItemObject {
-        if let obj = cacheRealm.objects(CalibreUnifiedCategoryItemObject.self).where({
-            $0.categoryName == categoryName && $0.name == name
-        }).first {
-            return obj
-        } else {
-            let obj = CalibreUnifiedCategoryItemObject()
-            
-            obj.categoryName = categoryName
-            obj.name = name
-            
-            cacheRealm.add(obj)
-            
-            return obj
-        }
-    }
+
     
     func getOrCreateLibrarySearchValueObject(librarySearchKey: LibrarySearchKey, cacheObj: CalibreLibrarySearchObject, serverUrl: String) -> CalibreLibrarySearchValueObject {
         if let sourceObjOpt = cacheObj.sources[serverUrl],
@@ -1290,30 +959,7 @@ class CalibreLibrarySearchManager: ObservableObject {
     
 
     
-    func retrieveUnifiedCategoryObject(_ categoryName: String, _ filter: String, _ unifiedCategories: Results<CalibreUnifiedCategoryObject>) -> CalibreUnifiedCategoryObject {
-        if let object = unifiedCategories.where({
-            $0.categoryName == categoryName
-            &&
-            $0.search == filter
-        }).first {
-            return object
-        }
-        
-        let object = CalibreUnifiedCategoryObject()
-        object.categoryName = categoryName
-        object.search = filter
-        object.totalNumber = 0
-        
-        return object
-    }
-    
-    func refreshUnifiedCategoryResult(_ categoryKey: CalibreUnifiedCategoryKey) {
-        self.categoryMergerHandlerSubject.send(categoryKey)
-    }
-    
-    func refreshLibraryCategory(library: CalibreLibrary, category: CalibreLibraryCategory) {
-        self.categoryRequestSubject.send(.init(library: library, category: category, reqId: 0, offset: 0, num: 0))
-    }
+
     
     private func cleanDuplicateLibrarySearchObjects() {
         let allObjs = cacheRealm.objects(CalibreLibrarySearchObject.self)

--- a/YetAnotherEBookReader/Models/CategoryModels.swift
+++ b/YetAnotherEBookReader/Models/CategoryModels.swift
@@ -1,0 +1,48 @@
+//
+//  CategoryModels.swift
+//  YetAnotherEBookReader
+//
+//  Created by Antigravity on 2026-06-12.
+//
+
+import Foundation
+
+struct LibraryCategoryItem: Equatable, Sendable, Codable {
+    let name: String
+    let averageRating: Double
+    let count: Int
+    let url: String
+}
+
+struct LibraryCategoryResult: Equatable, Sendable {
+    let libraryId: String
+    let categoryName: String
+    let items: [LibraryCategoryItem]
+    let generation: Date
+    let totalNumber: Int
+}
+
+struct UnifiedCategoryItem: Equatable, Sendable, Identifiable {
+    var id: String { name }
+    let categoryName: String
+    let name: String
+    let averageRating: Double
+    let count: Int
+    let libraryItems: [String: LibraryCategoryItem] // libraryId -> LibraryCategoryItem
+}
+
+struct UnifiedCategoryResult: Equatable, Sendable {
+    let categoryName: String
+    let search: String
+    let totalNumber: Int
+    let itemsCount: Int
+    let items: [UnifiedCategoryItem]
+}
+
+struct CategoryCacheSummary: Equatable, Sendable, Identifiable {
+    var id: String { categoryName }
+    let categoryName: String
+    let itemsCount: Int
+    let totalNumber: Int
+}
+

--- a/YetAnotherEBookReader/Models/ModelData.swift
+++ b/YetAnotherEBookReader/Models/ModelData.swift
@@ -1820,8 +1820,7 @@ final class ModelData: ObservableObject, CalibreServerConfigProvider, LibraryPro
             return
         }
         
-        guard request.library.hidden == false,
-              request.autoUpdateOnly == false || request.library.autoUpdate else {
+        guard request.library.hidden == false else {
             return
         }
         
@@ -1838,78 +1837,114 @@ final class ModelData: ObservableObject, CalibreServerConfigProvider, LibraryPro
         var result = await calibreServerService.getCustomColumns(request: request)
         result = await calibreServerService.getLibraryCategories(resultPrev: result)
         
-        var filter = ""
-        if request.incremental,
-           let libraryRealm = realm.object(
-            ofType: CalibreLibraryRealm.self,
-            forPrimaryKey: CalibreLibraryRealm.PrimaryKey(
-                serverUUID: result.request.library.server.uuid.uuidString,
-                libraryName: result.request.library.name)
-           ) {
-            let formatter = ISO8601DateFormatter()
-            formatter.formatOptions.formUnion(.withColonSeparatorInTimeZone)
-            formatter.timeZone = .current
-            let lastModifiedStr = formatter.string(from: libraryRealm.lastModified)
-            filter = "last_modified:\">=\(lastModifiedStr)\""
-        }
+        let shouldSyncBooks = request.autoUpdateOnly == false || request.library.autoUpdate
         
-        result = await calibreServerService.syncLibrary(resultPrev: result, filter: filter)
-        
-        self.librarySyncStatus[libraryId]?.isError = result.isError
-        
-        if result.isError == false {
-            let library = result.request.library
-            let serverUUID = library.server.uuid.uuidString
-            
-            await withCheckedContinuation { continuation in
-                ModelData.SaveBooksMetadataRealmQueue.async {
-                    try? self.updateLibraryRealm(library: library, realm: self.realmSaveBooksMetadata)
-                    continuation.resume()
-                }
+        if shouldSyncBooks {
+            var filter = ""
+            if request.incremental,
+               let libraryRealm = realm.object(
+                ofType: CalibreLibraryRealm.self,
+                forPrimaryKey: CalibreLibraryRealm.PrimaryKey(
+                    serverUUID: result.request.library.server.uuid.uuidString,
+                    libraryName: result.request.library.name)
+               ) {
+                let formatter = ISO8601DateFormatter()
+                formatter.formatOptions.formUnion(.withColonSeparatorInTimeZone)
+                formatter.timeZone = .current
+                let lastModifiedStr = formatter.string(from: libraryRealm.lastModified)
+                filter = "last_modified:\">=\(lastModifiedStr)\""
             }
             
-            result.categories.filter { $0.is_category }.forEach { category in
-                self.librarySearchManager.refreshLibraryCategory(library: library, category: category)
-            }
+            result = await calibreServerService.syncLibrary(resultPrev: result, filter: filter)
             
-            let dateFormatter = ISO8601DateFormatter()
-            let dateFormatter2 = ISO8601DateFormatter()
-            dateFormatter2.formatOptions.formUnion(.withFractionalSeconds)
+            self.librarySyncStatus[libraryId]?.isError = result.isError
             
-            var progress = 0
-            let total = result.list.book_ids.count
-            for chunk in result.list.book_ids.chunks(size: 1024) {
-                let preMsg = "\(progress) / \(total)"
-                let list = chunk.compactMap { id -> [String: Any]? in
-                    let idStr = id.description
-                    guard let lastModifiedStr = result.list.data.last_modified[idStr]?.v,
-                          let lastModified = dateFormatter.date(from: lastModifiedStr) ?? dateFormatter2.date(from: lastModifiedStr) else { return nil }
-                    return [
-                        "primaryKey": CalibreBookRealm.PrimaryKey(serverUUID: serverUUID, libraryName: library.name, id: idStr),
-                        "serverUUID": serverUUID,
-                        "libraryName": library.name,
-                        "lastModified": lastModified,
-                        "idInLib": id
-                    ]
-                }
-                progress += chunk.count
-                let postMsg = "\(progress) / \(total)"
-                await saveBookMetadata(metadata: .init(library: library, action: .save(list), preMsg: preMsg, postMsg: postMsg))
+            if result.isError == false {
+                let library = result.request.library
+                let serverUUID = library.server.uuid.uuidString
                 
-                if let lastMod = list.last?["lastModified"] as? Date {
-                    result.lastModified = lastMod
+                await withCheckedContinuation { continuation in
+                    ModelData.SaveBooksMetadataRealmQueue.async {
+                        try? self.updateLibraryRealm(library: library, realm: self.realmSaveBooksMetadata)
+                        continuation.resume()
+                    }
+                }
+                
+                result.categories.filter { $0.is_category }.forEach { category in
+                    Task {
+                        do {
+                            _ = try await self.librarySearchManager.libraryCategoryService.fetchAndCacheCategory(library: library, category: category)
+                        } catch {
+                            self.defaultLog.error("Failed to fetch and cache category \(category.name) for \(library.name): \(error.localizedDescription)")
+                        }
+                    }
+                }
+                
+                let dateFormatter = ISO8601DateFormatter()
+                let dateFormatter2 = ISO8601DateFormatter()
+                dateFormatter2.formatOptions.formUnion(.withFractionalSeconds)
+                
+                var progress = 0
+                let total = result.list.book_ids.count
+                for chunk in result.list.book_ids.chunks(size: 1024) {
+                    let preMsg = "\(progress) / \(total)"
+                    let list = chunk.compactMap { id -> [String: Any]? in
+                        let idStr = id.description
+                        guard let lastModifiedStr = result.list.data.last_modified[idStr]?.v,
+                              let lastModified = dateFormatter.date(from: lastModifiedStr) ?? dateFormatter2.date(from: lastModifiedStr) else { return nil }
+                        return [
+                            "primaryKey": CalibreBookRealm.PrimaryKey(serverUUID: serverUUID, libraryName: library.name, id: idStr),
+                            "serverUUID": serverUUID,
+                            "libraryName": library.name,
+                            "lastModified": lastModified,
+                            "idInLib": id
+                        ]
+                    }
+                    progress += chunk.count
+                    let postMsg = "\(progress) / \(total)"
+                    await saveBookMetadata(metadata: .init(library: library, action: .save(list), preMsg: preMsg, postMsg: postMsg))
+                    
+                    if let lastMod = list.last?["lastModified"] as? Date {
+                        result.lastModified = lastMod
+                    }
+                }
+                
+                if result.request.incremental == false {
+                    await saveBookMetadata(metadata: .init(library: library, action: .updateDeleted(result.list.data.last_modified), preMsg: "", postMsg: ""))
+                }
+                
+                await saveBookMetadata(metadata: .init(library: library, action: .complete(result.lastModified, result.result["result"] ?? [:]), preMsg: "", postMsg: "Success"))
+                
+                if isServerReachable(server: library.server) {
+                    self.calibreUpdatedSubject.send(.server(library.server))
+                    self.probeLibraryLastModifiedSubject.send(.init(library: library, autoUpdateOnly: false, incremental: false))
                 }
             }
+        } else {
+            let isError = !result.errmsg.isEmpty
+            self.librarySyncStatus[libraryId]?.isError = isError
+            self.librarySyncStatus[libraryId]?.isSync = false
             
-            if result.request.incremental == false {
-                await saveBookMetadata(metadata: .init(library: library, action: .updateDeleted(result.list.data.last_modified), preMsg: "", postMsg: ""))
-            }
-            
-            await saveBookMetadata(metadata: .init(library: library, action: .complete(result.lastModified, result.result["result"] ?? [:]), preMsg: "", postMsg: "Success"))
-            
-            if isServerReachable(server: library.server) {
-                self.calibreUpdatedSubject.send(.server(library.server))
-                self.probeLibraryLastModifiedSubject.send(.init(library: library, autoUpdateOnly: false, incremental: false))
+            if !isError {
+                let library = result.request.library
+                
+                result.categories.filter { $0.is_category }.forEach { category in
+                    Task {
+                        do {
+                            _ = try await self.librarySearchManager.libraryCategoryService.fetchAndCacheCategory(library: library, category: category)
+                        } catch {
+                            self.defaultLog.error("Failed to fetch and cache category \(category.name) for \(library.name): \(error.localizedDescription)")
+                        }
+                    }
+                }
+                
+                self.librarySyncStatus[libraryId]?.msg = "Success (Categories)"
+                
+                if isServerReachable(server: library.server) {
+                    self.calibreUpdatedSubject.send(.server(library.server))
+                }
+            } else {
+                self.librarySyncStatus[libraryId]?.msg = result.errmsg
             }
         }
     }

--- a/YetAnotherEBookReader/Models/Protocols/CategoryCacheRepository.swift
+++ b/YetAnotherEBookReader/Models/Protocols/CategoryCacheRepository.swift
@@ -1,0 +1,25 @@
+//
+//  CategoryCacheRepository.swift
+//  YetAnotherEBookReader
+//
+//  Created by Antigravity on 2026-06-12.
+//
+
+import Foundation
+
+protocol CategoryCacheRepository: Sendable {
+    func fetchLibraryCategoryResult(
+        libraryId: String,
+        categoryName: String
+    ) throws -> LibraryCategoryResult?
+    
+    func saveLibraryCategoryResult(
+        libraryId: String,
+        categoryName: String,
+        result: LibraryCategoryResult
+    ) throws
+    
+    func fetchCategorySummaries() throws -> [CategoryCacheSummary]
+    
+    func invalidateCategoryCache(libraryId: String, categoryName: String) throws
+}

--- a/YetAnotherEBookReader/Models/Repositories/RealmSearchCacheStore.swift
+++ b/YetAnotherEBookReader/Models/Repositories/RealmSearchCacheStore.swift
@@ -9,7 +9,7 @@ import Foundation
 import RealmSwift
 import Combine
 
-final class RealmSearchCacheStore: SearchCacheRepository, @unchecked Sendable {
+final class RealmSearchCacheStore: SearchCacheRepository, CategoryCacheRepository, @unchecked Sendable {
     private let config: Realm.Configuration
     private let modelData: ModelData
     
@@ -209,4 +209,113 @@ final class RealmSearchCacheStore: SearchCacheRepository, @unchecked Sendable {
         )
     }
     
+    func fetchLibraryCategoryResult(
+        libraryId: String,
+        categoryName: String
+    ) throws -> LibraryCategoryResult? {
+        let realm = try getRealm()
+        
+        guard let obj = realm.objects(CalibreLibraryCategoryObject.self)
+            .filter("libraryId == %@ AND categoryName == %@", libraryId, categoryName)
+            .first
+        else { return nil }
+        
+        let items = obj.items.map { itemObj in
+            LibraryCategoryItem(
+                name: itemObj.name,
+                averageRating: itemObj.averageRating,
+                count: itemObj.count,
+                url: itemObj.url
+            )
+        }
+        
+        return LibraryCategoryResult(
+            libraryId: obj.libraryId,
+            categoryName: obj.categoryName,
+            items: Array(items),
+            generation: obj.generation,
+            totalNumber: obj.totalNumber
+        )
+    }
+    
+    func saveLibraryCategoryResult(
+        libraryId: String,
+        categoryName: String,
+        result: LibraryCategoryResult
+    ) throws {
+        let realm = try getRealm()
+        
+        try realm.write {
+            var cacheObj = realm.objects(CalibreLibraryCategoryObject.self)
+                .filter("libraryId == %@ AND categoryName == %@", libraryId, categoryName)
+                .first
+                
+            if cacheObj == nil {
+                let newObj = CalibreLibraryCategoryObject()
+                newObj.libraryId = libraryId
+                newObj.categoryName = categoryName
+                realm.add(newObj)
+                cacheObj = newObj
+            }
+            
+            guard let obj = cacheObj else { return }
+            obj.generation = result.generation
+            obj.totalNumber = result.totalNumber
+            
+            obj.items.removeAll()
+            
+            for item in result.items {
+                let itemObj = realm.objects(CalibreLibraryCategoryItemObject.self)
+                    .filter("url == %@", item.url)
+                    .first ?? CalibreLibraryCategoryItemObject()
+                
+                if itemObj.realm == nil {
+                    itemObj.name = item.name
+                    itemObj.averageRating = item.averageRating
+                    itemObj.count = item.count
+                    itemObj.url = item.url
+                    realm.add(itemObj)
+                } else {
+                    if itemObj.name != item.name { itemObj.name = item.name }
+                    if itemObj.averageRating != item.averageRating { itemObj.averageRating = item.averageRating }
+                    if itemObj.count != item.count { itemObj.count = item.count }
+                }
+                obj.items.append(itemObj)
+            }
+        }
+    }
+    
+    func fetchCategorySummaries() throws -> [CategoryCacheSummary] {
+        let realm = try getRealm()
+        let objects = realm.objects(CalibreLibraryCategoryObject.self)
+        
+        var summariesByName: [String: (itemsCount: Int, totalNumber: Int)] = [:]
+        for obj in objects {
+            let name = obj.categoryName
+            let current = summariesByName[name] ?? (0, 0)
+            summariesByName[name] = (
+                current.itemsCount + obj.items.count,
+                current.totalNumber + obj.totalNumber
+            )
+        }
+        
+        return summariesByName.map { name, stats in
+            CategoryCacheSummary(
+                categoryName: name,
+                itemsCount: stats.itemsCount,
+                totalNumber: stats.totalNumber
+            )
+        }.sorted { $0.categoryName < $1.categoryName }
+    }
+    
+    func invalidateCategoryCache(libraryId: String, categoryName: String) throws {
+        let realm = try getRealm()
+        try realm.write {
+            if let cacheObj = realm.objects(CalibreLibraryCategoryObject.self)
+                .filter("libraryId == %@ AND categoryName == %@", libraryId, categoryName)
+                .first {
+                cacheObj.generation = .distantPast
+            }
+        }
+    }
 }

--- a/YetAnotherEBookReader/Models/Services/LibraryCategoryService.swift
+++ b/YetAnotherEBookReader/Models/Services/LibraryCategoryService.swift
@@ -1,0 +1,81 @@
+//
+//  LibraryCategoryService.swift
+//  YetAnotherEBookReader
+//
+//  Created by Antigravity on 2026-06-12.
+//
+
+import Foundation
+
+actor LibraryCategoryService {
+    private let service: CalibreServerService
+    private let repository: CategoryCacheRepository
+    
+    init(service: CalibreServerService, repository: CategoryCacheRepository) {
+        self.service = service
+        self.repository = repository
+    }
+    
+    func fetchAndCacheCategory(library: CalibreLibrary, category: CalibreLibraryCategory) async throws -> LibraryCategoryResult {
+        guard let serverUrl = service.getServerUrlByReachability(server: library.server) else {
+            throw URLError(.cannotFindHost)
+        }
+        
+        let categoryName = category.name
+        let libraryId = library.id
+        
+        // Check if we already have a fresh cache
+        if let existing = try? repository.fetchLibraryCategoryResult(libraryId: libraryId, categoryName: categoryName) {
+            if existing.generation >= library.lastModified {
+                return existing
+            }
+        }
+        
+        var items: [LibraryCategoryItem] = []
+        var offset = 0
+        let limit = 10000 // page limit
+        
+        while true {
+            guard var urlComponents = URLComponents(string: category.url) else {
+                throw URLError(.badURL)
+            }
+            urlComponents.queryItems = [
+                URLQueryItem(name: "num", value: limit.description),
+                URLQueryItem(name: "offset", value: offset.description)
+            ]
+            
+            guard let url = urlComponents.url(relativeTo: serverUrl) else {
+                throw URLError(.badURL)
+            }
+            
+            let session = service.urlSession(server: library.server, qos: .background)
+            let (data, _) = try await session.data(from: url)
+            let result = try JSONDecoder().decode(LibraryCategoryListResult.self, from: data)
+            
+            let fetched = result.items.map { item in
+                LibraryCategoryItem(
+                    name: item.name,
+                    averageRating: item.average_rating,
+                    count: item.count,
+                    url: item.url
+                )
+            }
+            items.append(contentsOf: fetched)
+            
+            if items.count >= result.total_num || fetched.isEmpty {
+                let finalResult = LibraryCategoryResult(
+                    libraryId: libraryId,
+                    categoryName: categoryName,
+                    items: items,
+                    generation: library.lastModified,
+                    totalNumber: result.total_num
+                )
+                
+                try repository.saveLibraryCategoryResult(libraryId: libraryId, categoryName: categoryName, result: finalResult)
+                return finalResult
+            }
+            
+            offset = items.count
+        }
+    }
+}

--- a/YetAnotherEBookReader/Models/Services/UnifiedCategoryMergeService.swift
+++ b/YetAnotherEBookReader/Models/Services/UnifiedCategoryMergeService.swift
@@ -1,0 +1,63 @@
+//
+//  UnifiedCategoryMergeService.swift
+//  YetAnotherEBookReader
+//
+//  Created by Antigravity on 2026-06-12.
+//
+
+import Foundation
+
+struct UnifiedCategoryMergeService: Sendable {
+    func merge(
+        categoryName: String,
+        searchString: String,
+        results: [LibraryCategoryResult]
+    ) -> UnifiedCategoryResult {
+        var grouped: [String: [String: LibraryCategoryItem]] = [:] // Name -> [LibraryId -> Item]
+        
+        for result in results {
+            let libraryId = result.libraryId
+            for item in result.items {
+                if !searchString.isEmpty {
+                    guard item.name.localizedCaseInsensitiveContains(searchString) else { continue }
+                }
+                
+                var entry = grouped[item.name] ?? [:]
+                entry[libraryId] = item
+                grouped[item.name] = entry
+            }
+        }
+        
+        var unifiedItems: [UnifiedCategoryItem] = []
+        var totalNumber = 0
+        
+        for (name, libItems) in grouped {
+            let stats = libItems.values.reduce((0, 0.0)) { partialResult, item in
+                (partialResult.0 + item.count, partialResult.1 + item.averageRating * Double(item.count))
+            }
+            let totalCount = stats.0
+            let avgRating = totalCount > 0 ? stats.1 / Double(totalCount) : 0.0
+            
+            let unifiedItem = UnifiedCategoryItem(
+                categoryName: categoryName,
+                name: name,
+                averageRating: avgRating,
+                count: totalCount,
+                libraryItems: libItems
+            )
+            unifiedItems.append(unifiedItem)
+            totalNumber += totalCount
+        }
+        
+        // Sort items alphabetically by name
+        unifiedItems.sort { $0.name.localizedCompare($1.name) == .orderedAscending }
+        
+        return UnifiedCategoryResult(
+            categoryName: categoryName,
+            search: searchString,
+            totalNumber: totalNumber,
+            itemsCount: unifiedItems.count,
+            items: unifiedItems
+        )
+    }
+}

--- a/YetAnotherEBookReader/Models/Services/UnifiedCategoryService.swift
+++ b/YetAnotherEBookReader/Models/Services/UnifiedCategoryService.swift
@@ -1,0 +1,38 @@
+//
+//  UnifiedCategoryService.swift
+//  YetAnotherEBookReader
+//
+//  Created by Antigravity on 2026-06-12.
+//
+
+import Foundation
+
+actor UnifiedCategoryService {
+    private let mergeService: UnifiedCategoryMergeService
+    private let repository: CategoryCacheRepository
+    private let libraryProvider: LibraryProvider
+    
+    init(
+        mergeService: UnifiedCategoryMergeService = UnifiedCategoryMergeService(),
+        repository: CategoryCacheRepository,
+        libraryProvider: LibraryProvider
+    ) {
+        self.mergeService = mergeService
+        self.repository = repository
+        self.libraryProvider = libraryProvider
+    }
+    
+    func mergeCategory(categoryName: String, searchString: String) async -> UnifiedCategoryResult {
+        let calibreLibraries = await libraryProvider.getLibraries()
+        let activeLibraries = calibreLibraries.values.filter { !$0.hidden && !$0.server.removed }
+        
+        var results: [LibraryCategoryResult] = []
+        for library in activeLibraries {
+            if let result = try? repository.fetchLibraryCategoryResult(libraryId: library.id, categoryName: categoryName) {
+                results.append(result)
+            }
+        }
+        
+        return mergeService.merge(categoryName: categoryName, searchString: searchString, results: results)
+    }
+}

--- a/YetAnotherEBookReader/Views/BookDetailView/BookDetailSubviews.swift
+++ b/YetAnotherEBookReader/Views/BookDetailView/BookDetailSubviews.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 import KingfisherSwiftUI
-import RealmSwift
 
 struct BookCoverView: View {
     @ObservedObject var viewModel: BookDetailViewModel

--- a/YetAnotherEBookReader/Views/BookDetailView/BookDetailView.swift
+++ b/YetAnotherEBookReader/Views/BookDetailView/BookDetailView.swift
@@ -1,5 +1,5 @@
 //
-//  BookView.swift
+//  BookDetailView.swift
 //  YetAnotherEBookReader
 //
 //  Created by 京太郎 on 2021/1/25.
@@ -8,17 +8,13 @@
 import Foundation
 import OSLog
 import SwiftUI
-import RealmSwift
-//import struct Kingfisher.KFImage
 import KingfisherSwiftUI
 
 struct BookDetailView: View {
     @Environment(\.horizontalSizeClass) var sizeClass
     @Environment(\.openURL) var openURL
     
-    @ObservedRealmObject var book: CalibreBookRealm
-    
-    @ObservedResults(BookDeviceReadingPositionRealm.self, configuration: ModelData.shared?.realmConf) var readingPositions
+    let bookId: String
     
     var viewMode: Mode
     
@@ -26,21 +22,15 @@ struct BookDetailView: View {
     
     var defaultLog = Logger()
     
-
     @StateObject private var _viewModel = BookDetailViewModel()
     
     var body: some View {
-        
         ScrollView {
-            Text(book.title)
-            if let calibreBook = _viewModel.convert(bookRealm: book) {
+            if let calibreBook = _viewModel.calibreBook {
+                Text(calibreBook.title)
                 viewContent(book: calibreBook, isCompat: sizeClass == .compact)
-                    .onAppear() {
-                        _viewModel.setup(book: book, calibreBook: calibreBook)
-                        _viewModel.fetchMetadata(book: calibreBook)
-                    }
                     .padding(EdgeInsets(top: 5, leading: 10, bottom: 5, trailing: 10))
-                    .navigationTitle(Text(book.title))
+                    .navigationTitle(Text(calibreBook.title))
                     .toolbar {
                         toolbarContent(book: calibreBook)
                     }
@@ -48,7 +38,15 @@ struct BookDetailView: View {
                         return Alert(title: Text(item.id), message: Text(item.msg ?? item.id))
                     }
             } else {
-                EmptyView()
+                Text("Loading book details...")
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding()
+            }
+        }
+        .onAppear() {
+            _viewModel.setup(bookId: bookId)
+            if let calibreBook = _viewModel.calibreBook {
+                _viewModel.fetchMetadata(book: calibreBook)
             }
         }
     }

--- a/YetAnotherEBookReader/Views/BookDetailView/BookDetailViewModel.swift
+++ b/YetAnotherEBookReader/Views/BookDetailView/BookDetailViewModel.swift
@@ -8,10 +8,13 @@
 import Foundation
 import Combine
 import SwiftUI
+import RealmSwift
 
 class BookDetailViewModel: ObservableObject {
     @Published var listVM: ReadingPositionListViewModel?
     @Published var previewViewModel = BookPreviewViewModel()
+    @Published var calibreBook: CalibreBook?
+    private var bookObserverToken: AnyCancellable?
     
     @Published var alertItem: AlertItem?
     
@@ -96,9 +99,7 @@ class BookDetailViewModel: ObservableObject {
         fetchTask?.cancel()
     }
     
-    func setup(book: CalibreBookRealm, calibreBook: CalibreBook) {
-        self.book = book
-        
+    func setup(bookId: String) {
         guard let modelData = self.modelData else {
             print("Warning: BookDetailViewModel setup called before modelData was set")
             return
@@ -106,14 +107,36 @@ class BookDetailViewModel: ObservableObject {
         
         modelData.downloadManager.$activeDownloads.assign(to: &$activeDownloads)
         
+        guard let bookRealm = modelData.realm.object(ofType: CalibreBookRealm.self, forPrimaryKey: bookId) else {
+            print("Error: CalibreBookRealm not found for primary key \(bookId)")
+            return
+        }
+        self.book = bookRealm
+        
+        let calibreBook = modelData.convert(bookRealm: bookRealm)
+        self.calibreBook = calibreBook
+        
         if self.listVM == nil {
-            self.listVM = ReadingPositionListViewModel(
-                modelData: modelData, book: calibreBook, positions: calibreBook.readPos.getDevices().sorted(by: { $0.epoch > $1.epoch })
-            )
-        } else {
+            if let calibreBook = calibreBook {
+                self.listVM = ReadingPositionListViewModel(
+                    modelData: modelData, book: calibreBook, positions: calibreBook.readPos.getDevices().sorted(by: { $0.epoch > $1.epoch })
+                )
+            }
+        } else if let calibreBook = calibreBook {
             self.listVM?.book = calibreBook
             self.listVM?.positions = calibreBook.readPos.getDevices().sorted(by: { $0.epoch > $1.epoch })
         }
+        
+        bookObserverToken = bookRealm.objectWillChange
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard let self = self, let b = self.book, let modelData = self.modelData else { return }
+                if let updatedCalibreBook = modelData.convert(bookRealm: b) {
+                    self.calibreBook = updatedCalibreBook
+                    self.listVM?.book = updatedCalibreBook
+                    self.listVM?.positions = updatedCalibreBook.readPos.getDevices().sorted(by: { $0.epoch > $1.epoch })
+                }
+            }
     }
     
     func fetchMetadata(book: CalibreBook) {

--- a/YetAnotherEBookReader/Views/LibraryInfoView/LibraryInfoBookListInfoView.swift
+++ b/YetAnotherEBookReader/Views/LibraryInfoView/LibraryInfoBookListInfoView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import RealmSwift
 
 struct LibraryInfoBookListInfoView: View {
     @EnvironmentObject var modelData: ModelData

--- a/YetAnotherEBookReader/Views/LibraryInfoView/LibraryInfoBookListView.swift
+++ b/YetAnotherEBookReader/Views/LibraryInfoView/LibraryInfoBookListView.swift
@@ -191,7 +191,7 @@ struct LibraryInfoBookListView: View {
         Group {
             if let bookRealm = modelData.getBookRealm(forPrimaryKey: book.inShelfId) {
                 NavigationLink (
-                    destination: BookDetailView(book: bookRealm, viewMode: .LIBRARY),
+                    destination: BookDetailView(bookId: book.inShelfId, viewMode: .LIBRARY),
                     tag: book.inShelfId,
                     selection: $modelData.selectedBookId
                 ) {

--- a/YetAnotherEBookReader/Views/LibraryInfoView/LibraryInfoBookListView.swift
+++ b/YetAnotherEBookReader/Views/LibraryInfoView/LibraryInfoBookListView.swift
@@ -6,8 +6,6 @@
 //
 
 import SwiftUI
-import RealmSwift
-//import struct Kingfisher.KFImage
 import KingfisherSwiftUI
 
 struct LibraryInfoBookListView: View {

--- a/YetAnotherEBookReader/Views/LibraryInfoView/LibraryInfoBookRow.swift
+++ b/YetAnotherEBookReader/Views/LibraryInfoView/LibraryInfoBookRow.swift
@@ -6,8 +6,6 @@
 //
 
 import SwiftUI
-import RealmSwift
-//import struct Kingfisher.KFImage
 import KingfisherSwiftUI
 
 struct LibraryInfoBookRow: View {

--- a/YetAnotherEBookReader/Views/LibraryInfoView/LibraryInfoCategoryItemsView.swift
+++ b/YetAnotherEBookReader/Views/LibraryInfoView/LibraryInfoCategoryItemsView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import RealmSwift
 
 struct LibraryInfoCategoryItemsView: View {
     @EnvironmentObject var modelData: ModelData
@@ -14,106 +13,75 @@ struct LibraryInfoCategoryItemsView: View {
     @EnvironmentObject var viewModel: LibraryInfoView.ViewModel
     @EnvironmentObject var unifiedSearchViewModel: UnifiedSearchViewModel
     
-    @ObservedRealmObject var unifiedCategory: CalibreUnifiedCategoryObject
-    
-    @ObservedResults(CalibreLibraryCategoryObject.self, configuration: ModelData.shared?.realmConf, sortDescriptor: .init(keyPath: "libraryId")) var libraryCategories
+    let categoryName: String
+    @ObservedObject var categoryViewModel: UnifiedCategoryViewModel
 
     var body: some View {
         VStack {
-            #if DEBUG
-            List {
-                ForEach(libraryCategories.where({ $0.categoryName == unifiedCategory.categoryName})) { libraryCategory in
-                    VStack {
-                        HStack {
-                            Text(libraryCategory.libraryId)
-                            Spacer()
-                        }
-                        HStack {
-                            Text("\(libraryCategory.generation)")
-                            Spacer()
-                            Text("\(libraryCategory.items.count)")
-                        }
-                    }
-                }
-            }
-            #endif
 
-            if unifiedCategory.items.isEmpty,
-               unifiedCategory.itemsCount > 999,
-               unifiedCategory.totalNumber > 999 {
-                VStack {
-                    Text("Found \(unifiedCategory.itemsCount) items, too many to list them all, please use filter")
-                }
-            } else {
-                List {
-                    ForEach(unifiedCategory.items) { categoryItem in
-                        NavigationLink(tag: categoryItem.name, selection: $viewModel.categoryItemSelected) {
-                            bookListView()
-                                .onAppear {
-                                    if viewModel.filterCriteriaCategory[unifiedCategory.categoryName]?.contains(categoryItem.name) == true {
-                                        return
-                                    }
-                                    
-                                    resetSearchCriteria()
-                                    
-                                    viewModel.filterCriteriaCategory[unifiedCategory.categoryName] = .init([categoryItem.name])
-                                    
-                                    if viewModel.categoriesSelected == "Series" {
-                                        if viewModel.sortCriteria.by != .SeriesIndex {
-                                            viewModel.lastSortCriteria.append(viewModel.sortCriteria)
+            if let result = categoryViewModel.unifiedCategoryResult {
+                if result.items.isEmpty,
+                   result.itemsCount > 999,
+                   result.totalNumber > 999 {
+                    VStack {
+                        Text("Found \(result.itemsCount) items, too many to list them all, please use filter")
+                    }
+                } else {
+                    List {
+                        ForEach(result.items) { categoryItem in
+                            NavigationLink(tag: categoryItem.name, selection: $viewModel.categoryItemSelected) {
+                                bookListView()
+                                    .onAppear {
+                                        if viewModel.filterCriteriaCategory[categoryName]?.contains(categoryItem.name) == true {
+                                            return
                                         }
                                         
-                                        viewModel.sortCriteria.by = .SeriesIndex
-                                        viewModel.sortCriteria.ascending = true
-                                    } else if viewModel.categoriesSelected == "Publisher" || viewModel.categoriesSelected == "Authors" {
-                                        if viewModel.sortCriteria.by != .Publication {
-                                            viewModel.lastSortCriteria.append(viewModel.sortCriteria)
+                                        resetSearchCriteria()
+                                        
+                                        viewModel.filterCriteriaCategory[categoryName] = .init([categoryItem.name])
+                                        
+                                        if viewModel.categoriesSelected == "Series" {
+                                            if viewModel.sortCriteria.by != .SeriesIndex {
+                                                viewModel.lastSortCriteria.append(viewModel.sortCriteria)
+                                            }
+                                            
+                                            viewModel.sortCriteria.by = .SeriesIndex
+                                            viewModel.sortCriteria.ascending = true
+                                        } else if viewModel.categoriesSelected == "Publisher" || viewModel.categoriesSelected == "Authors" {
+                                            if viewModel.sortCriteria.by != .Publication {
+                                                viewModel.lastSortCriteria.append(viewModel.sortCriteria)
+                                            }
+                                            
+                                            viewModel.sortCriteria.by = .Publication
+                                            viewModel.sortCriteria.ascending = false
+                                        }
+                                        else {
+                                            viewModel.sortCriteria.by = .Modified
+                                            viewModel.sortCriteria.ascending = false
                                         }
                                         
-                                        viewModel.sortCriteria.by = .Publication
-                                        viewModel.sortCriteria.ascending = false
+                                        resetToFirstPage()
                                     }
-                                    else {
-                                        viewModel.sortCriteria.by = .Modified
-                                        viewModel.sortCriteria.ascending = false
-                                    }
-                                    
-                                    resetToFirstPage()
-                                }
-                                .navigationTitle("\(unifiedCategory.categoryName): \(categoryItem.name)")
-                        } label: {
-                            Text(categoryItem.name)
+                                    .navigationTitle("\(categoryName): \(categoryItem.name)")
+                            } label: {
+                                Text(categoryItem.name)
+                            }
+                            .isDetailLink(false)
                         }
-                        .isDetailLink(false)
                     }
                 }
+            } else if categoryViewModel.isLoading {
+                ProgressView("Loading items...")
+            } else {
+                Text("No items")
             }
         }
         .toolbar {
             Button {
-//                modelData.librarySearchManager.refreshUnifiedCategoryResult(unifiedCategory.key)
-                libraryCategories
-                    .where({ $0.categoryName == unifiedCategory.categoryName}).forEach { libraryCategory in
-                        
-                        guard let library = modelData.calibreLibraries[libraryCategory.libraryId],
-                            let realm = libraryCategory.realm?.thaw(),
-                            let thawed = libraryCategory.thaw()
-                        else {
-                            return
-                        }
-                        
-                        try! realm.write {
-                            thawed.generation = .distantPast
-                        }
-                        
-                        Task {
-                            await modelData.syncLibrary(request: .init(library: library, autoUpdateOnly: true, incremental: true))
-                        }
-                    }
+                categoryViewModel.forceRefreshCategory(categoryName: categoryName)
             } label: {
                 Image(systemName: "arrow.triangle.2.circlepath")
             }
-
         }
     }
     
@@ -137,15 +105,5 @@ struct LibraryInfoCategoryItemsView: View {
     
     func resetToFirstPage() {
         unifiedSearchViewModel.startSearch(key: viewModel.currentLibrarySearchResultKey)
-    }
-}
-
-struct LibraryInfoCategoryItemsView_Previews: PreviewProvider {
-    @ObservedResults(CalibreUnifiedCategoryObject.self, configuration: ModelData.shared?.realmConf, sortDescriptor: .init(keyPath: "categoryName")) static var unifiedCategories
-    
-    static var previews: some View {
-        if let unifiedCategoryObject = unifiedCategories.first {
-            LibraryInfoCategoryItemsView(unifiedCategory: unifiedCategoryObject)
-        }
     }
 }

--- a/YetAnotherEBookReader/Views/LibraryInfoView/LibraryInfoCategoryItemsView.swift
+++ b/YetAnotherEBookReader/Views/LibraryInfoView/LibraryInfoCategoryItemsView.swift
@@ -91,6 +91,7 @@ struct LibraryInfoCategoryItemsView: View {
             if unifiedSearchViewModel.unifiedSearchResult != nil {
                 LibraryInfoBookListView()
                     .environmentObject(unifiedSearchViewModel)
+                    .environmentObject(viewModel)
             } else {
                 Text("Preparing Book List")
             }

--- a/YetAnotherEBookReader/Views/LibraryInfoView/LibraryInfoCategoryListView.swift
+++ b/YetAnotherEBookReader/Views/LibraryInfoView/LibraryInfoCategoryListView.swift
@@ -6,80 +6,28 @@
 //
 
 import SwiftUI
-import RealmSwift
 
 struct LibraryInfoCategoryListView: View {
     @EnvironmentObject var modelData: ModelData
-    
     @EnvironmentObject var viewModel: LibraryInfoView.ViewModel
+    @EnvironmentObject var unifiedSearchViewModel: UnifiedSearchViewModel
 
-
-    @ObservedResults(CalibreUnifiedCategoryObject.self, configuration: ModelData.shared?.realmConf, sortDescriptor: .init(keyPath: "categoryName")) var unifiedCategories
-    
-    @ObservedResults(CalibreUnifiedCategoryObject.self, configuration: ModelData.shared?.realmConf, where: { $0.search == "" }, sortDescriptor: .init(keyPath: "categoryName")) var unifiedCategoriesKeys
-    
     var body: some View {
         Section {
-            ForEach(unifiedCategoriesKeys) { unifiedCategoryKey in
-                NavigationLink(tag: unifiedCategoryKey.categoryName, selection: $viewModel.categoriesSelected) {
-//                NavigationLink {
-                    ZStack {
-                        TextField("Filter \(unifiedCategoryKey.categoryName)", text: $viewModel.categoryFilterString, onCommit: {
-                            updateViewModel()
-                        })
-                        .keyboardType(.webSearch)
-                        .padding([.leading, .trailing], 24)
-                        .onChange(of: viewModel.categoryFilterString) { newValue in
-                            viewModel.categoryFilter = viewModel.categoryFilterString.trimmingCharacters(in: .whitespacesAndNewlines)
-                        }
-                        HStack {
-                            Spacer()
-                            Button {
-                                viewModel.categoryFilterString = ""
-                                updateViewModel()
-                            } label: {
-                                Image(systemName: "xmark.circle.fill")
-                                    .foregroundColor(.gray)
-                            }
-                            .disabled(viewModel.categoryFilterString.isEmpty)
-                            
-                        }.padding([.leading, .trailing], 4)
-                    }
-                    
-                    Divider()
-                    
-                    ZStack {
-                        if let unifiedCategory = viewModel.unifiedCategoryObject {
-                            LibraryInfoCategoryItemsView(unifiedCategory: unifiedCategory)
-                                .environmentObject(viewModel)
-                        } else {
-                            Text("Missing List")
-                        }
-                    }
-                    .navigationTitle("Category: \(unifiedCategoryKey.categoryName)")
-                    .onAppear {
-                        guard let categoryName = viewModel.categoriesSelected,
-                              categoryName != viewModel.categoryName
-                        else { return }
-                        
-                        viewModel.categoryFilterString = ""
-                        updateViewModel()
-                    }
-                    .onDisappear {
-                        if viewModel.categoriesSelected == nil {
-                            viewModel.categoryName = ""
-                        }
-                    }
+            ForEach(viewModel.availableCategories) { summary in
+                NavigationLink(tag: summary.categoryName, selection: $viewModel.categoriesSelected) {
+                    CategoryDetailView(categoryName: summary.categoryName)
+                        .environmentObject(viewModel)
+                        .environmentObject(unifiedSearchViewModel)
                 } label: {
                     #if DEBUG
                     HStack {
-                        Text("\(unifiedCategoryKey.categoryName)")
+                        Text(summary.categoryName)
                         Spacer()
-                        Text("\(unifiedCategoryKey.itemsCount) (\(unifiedCategoryKey.items.count)) (\(unifiedCategoryKey.totalNumber))")
-                        
+                        Text("\(summary.itemsCount) (\(summary.totalNumber))")
                     }
                     #else
-                    Text("\(unifiedCategoryKey.categoryName)")
+                    Text(summary.categoryName)
                     #endif
                 }
                 .isDetailLink(false)
@@ -88,28 +36,63 @@ struct LibraryInfoCategoryListView: View {
             Text("Browse by Category")
         }
     }
-    
-    func updateViewModel() {
-        guard let categoryName = viewModel.categoriesSelected,
-              categoryName.isEmpty == false
-        else {
-            return
-        }
-        
-        viewModel.categoryName = categoryName
-        
-        let object = modelData.librarySearchManager.retrieveUnifiedCategoryObject(viewModel.categoryName, viewModel.categoryFilter, unifiedCategories)
-        
-        if object.realm == nil {
-            $unifiedCategories.append(object)
-        }
-        
-        viewModel.setUnifiedCategoryObject(modelData, object)
-    }
 }
 
-//struct LibraryInfoCategoryListView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        LibraryInfoCategoryListView()
-//    }
-//}
+struct CategoryDetailView: View {
+    let categoryName: String
+    @EnvironmentObject var modelData: ModelData
+    @EnvironmentObject var viewModel: LibraryInfoView.ViewModel
+    @EnvironmentObject var unifiedSearchViewModel: UnifiedSearchViewModel
+    @StateObject private var categoryViewModel = UnifiedCategoryViewModel()
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            ZStack {
+                TextField("Filter \(categoryName)", text: $viewModel.categoryFilterString, onCommit: {
+                    triggerMerge()
+                })
+                .keyboardType(.webSearch)
+                .padding([.leading, .trailing], 24)
+                .onChange(of: viewModel.categoryFilterString) { newValue in
+                    viewModel.categoryFilter = viewModel.categoryFilterString.trimmingCharacters(in: .whitespacesAndNewlines)
+                }
+                HStack {
+                    Spacer()
+                    Button {
+                        viewModel.categoryFilterString = ""
+                        viewModel.categoryFilter = ""
+                        triggerMerge()
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundColor(.gray)
+                    }
+                    .disabled(viewModel.categoryFilterString.isEmpty)
+                    
+                }.padding([.leading, .trailing], 4)
+            }
+            .frame(height: 44)
+            
+            Divider()
+            
+            LibraryInfoCategoryItemsView(categoryName: categoryName, categoryViewModel: categoryViewModel)
+                .environmentObject(viewModel)
+                .environmentObject(unifiedSearchViewModel)
+        }
+        .navigationTitle("Category: \(categoryName)")
+        .onAppear {
+            viewModel.categoryFilterString = ""
+            viewModel.categoryFilter = ""
+            triggerMerge()
+        }
+        .onDisappear {
+            if viewModel.categoriesSelected == nil {
+                viewModel.categoryName = ""
+            }
+        }
+    }
+    
+    private func triggerMerge() {
+        viewModel.categoryName = categoryName
+        categoryViewModel.mergeCategory(categoryName: categoryName, searchString: viewModel.categoryFilter)
+    }
+}

--- a/YetAnotherEBookReader/Views/LibraryInfoView/LibraryInfoView.swift
+++ b/YetAnotherEBookReader/Views/LibraryInfoView/LibraryInfoView.swift
@@ -143,6 +143,7 @@ struct LibraryInfoView: View {
             if unifiedSearchViewModel.unifiedSearchResult != nil {
                 LibraryInfoBookListView()
                     .environmentObject(unifiedSearchViewModel)
+                    .environmentObject(viewModel)
             } else {
                 Text("Preparing Book List")
             }

--- a/YetAnotherEBookReader/Views/LibraryInfoView/LibraryInfoView.swift
+++ b/YetAnotherEBookReader/Views/LibraryInfoView/LibraryInfoView.swift
@@ -8,15 +8,12 @@
 import SwiftUI
 import OSLog
 import Combine
-import RealmSwift
 //import struct Kingfisher.KFImage
 import KingfisherSwiftUI
 
 @available(macCatalyst 14.0, *)
 struct LibraryInfoView: View {
     @EnvironmentObject var modelData: ModelData
-    
-    @ObservedResults(CalibreUnifiedCategoryObject.self, configuration: ModelData.shared?.realmConf, where: { $0.search == "" && $0.itemsCount > 0 }) var unifiedCategories
     
     @StateObject var viewModel = ViewModel()
     @StateObject var unifiedSearchViewModel = UnifiedSearchViewModel()
@@ -57,7 +54,7 @@ struct LibraryInfoView: View {
             List {
                 combinedListView()
                 
-                if unifiedCategories.isEmpty == false {
+                if viewModel.availableCategories.isEmpty == false {
                     LibraryInfoCategoryListView()
                 }
                 
@@ -72,6 +69,7 @@ struct LibraryInfoView: View {
         .listStyle(PlainListStyle())
         .onAppear {
             viewModel.calibreLibraries = modelData.calibreLibraries
+            viewModel.setupDatabaseObserver()
             
             libraryList = modelData.calibreLibraries.values
                 .filter { $0.hidden == false }

--- a/YetAnotherEBookReader/Views/LibraryInfoView/LibraryInfoViewModel.swift
+++ b/YetAnotherEBookReader/Views/LibraryInfoView/LibraryInfoViewModel.swift
@@ -97,33 +97,28 @@ extension LibraryInfoView {
         
         @Published var categoryFilterString: String = ""
         
-        @Published private(set) var unifiedCategoryObject: CalibreUnifiedCategoryObject?
+        @Published var availableCategories: [CategoryCacheSummary] = []
         
-        var unifiedCategoryUpdateCancellable: AnyCancellable?
+        private var databaseObserver: AnyCancellable?
         
-        func setUnifiedCategoryObject(_ modelData: ModelData, _ unifiedCategoryObject: CalibreUnifiedCategoryObject?) {
-            unifiedCategoryUpdateCancellable?.cancel()
-            unifiedCategoryUpdateCancellable = nil
-            
-            self.unifiedCategoryObject = unifiedCategoryObject
-            
-            guard let unifiedCategoryObject = unifiedCategoryObject
-            else {
-                return
+        func fetchAvailableCategories() {
+            guard let modelData = ModelData.shared else { return }
+            let repository = modelData.librarySearchManager.categoryCacheRepository
+            if let summaries = try? repository?.fetchCategorySummaries() {
+                self.availableCategories = summaries
             }
+        }
+        
+        func setupDatabaseObserver() {
+            guard let modelData = ModelData.shared, databaseObserver == nil else { return }
             
-            self.unifiedCategoryUpdateCancellable =  modelData.realm.objects(CalibreLibraryCategoryObject.self)
-                .where {
-                    $0.categoryName == unifiedCategoryObject.categoryName
-                }
+            fetchAvailableCategories()
+            
+            databaseObserver = modelData.realm.objects(CalibreLibraryCategoryObject.self)
                 .changesetPublisher(keyPaths: ["items"])
-                .sink { changes in
-                    switch changes {
-                    case .initial(_), .error(_):
-                        break
-                    case .update(_, deletions: let deletions, insertions: let insertions, modifications: let modifications):
-                        modelData.librarySearchManager.refreshUnifiedCategoryResult(unifiedCategoryObject.key)
-                    }
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] _ in
+                    self?.fetchAvailableCategories()
                 }
         }
     }

--- a/YetAnotherEBookReader/Views/LibraryInfoView/UnifiedCategoryViewModel.swift
+++ b/YetAnotherEBookReader/Views/LibraryInfoView/UnifiedCategoryViewModel.swift
@@ -1,0 +1,96 @@
+//
+//  UnifiedCategoryViewModel.swift
+//  YetAnotherEBookReader
+//
+//  Created by Antigravity on 2026-06-12.
+//
+
+import Foundation
+import SwiftUI
+import Combine
+import RealmSwift
+
+@MainActor
+class UnifiedCategoryViewModel: ObservableObject {
+    @Published private(set) var unifiedCategoryResult: UnifiedCategoryResult? = nil
+    @Published private(set) var isLoading = false
+    
+    private let unifiedCategoryService: UnifiedCategoryService
+    private let modelData: ModelData
+    private var mergeTask: Task<Void, Never>?
+    
+    private var currentCategoryName: String?
+    private var currentSearchString: String = ""
+    private var databaseObserver: AnyCancellable?
+    
+    init(unifiedCategoryService: UnifiedCategoryService? = nil, modelData: ModelData? = nil) {
+        guard let resolvedModelData = modelData ?? ModelData.shared else {
+            fatalError("ModelData.shared must be initialized before creating UnifiedCategoryViewModel")
+        }
+        self.modelData = resolvedModelData
+        self.unifiedCategoryService = unifiedCategoryService ?? resolvedModelData.librarySearchManager.unifiedCategoryService
+    }
+    
+    func mergeCategory(categoryName: String, searchString: String) {
+        self.currentCategoryName = categoryName
+        self.currentSearchString = searchString
+        
+        setupDatabaseObserver(for: categoryName)
+        
+        mergeTask?.cancel()
+        isLoading = true
+        
+        mergeTask = Task {
+            let result = await unifiedCategoryService.mergeCategory(categoryName: categoryName, searchString: searchString)
+            guard !Task.isCancelled else { return }
+            self.unifiedCategoryResult = result
+            self.isLoading = false
+        }
+    }
+    
+    private func setupDatabaseObserver(for categoryName: String) {
+        guard databaseObserver == nil else { return }
+        
+        databaseObserver = modelData.realm.objects(CalibreLibraryCategoryObject.self)
+            .where {
+                $0.categoryName == categoryName
+            }
+            .changesetPublisher(keyPaths: ["items"])
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] changes in
+                guard let self = self else { return }
+                switch changes {
+                case .initial(_):
+                    break
+                case .update(_, deletions: _, insertions: _, modifications: _):
+                    self.retriggerMerge()
+                case .error(_):
+                    break
+                }
+            }
+    }
+    
+    private func retriggerMerge() {
+        guard let categoryName = currentCategoryName else { return }
+        mergeTask?.cancel()
+        mergeTask = Task {
+            let result = await unifiedCategoryService.mergeCategory(categoryName: categoryName, searchString: self.currentSearchString)
+            guard !Task.isCancelled else { return }
+            self.unifiedCategoryResult = result
+        }
+    }
+    
+    func forceRefreshCategory(categoryName: String) {
+        let calibreLibraries = modelData.calibreLibraries.values
+        let activeLibraries = calibreLibraries.filter { !$0.hidden && !$0.server.removed }
+        let repository = modelData.librarySearchManager.categoryCacheRepository
+        
+        for library in activeLibraries {
+            try? repository?.invalidateCategoryCache(libraryId: library.id, categoryName: categoryName)
+            
+            Task {
+                await modelData.syncLibrary(request: .init(library: library, autoUpdateOnly: true, incremental: true))
+            }
+        }
+    }
+}

--- a/YetAnotherEBookReader/Views/SettingsView/ReaderOptions/ReaderOptionsView.swift
+++ b/YetAnotherEBookReader/Views/SettingsView/ReaderOptions/ReaderOptionsView.swift
@@ -9,39 +9,32 @@ import SwiftUI
 import Combine
 
 struct ReaderOptionsView: View {
-    @EnvironmentObject var modelData: ModelData
-    @EnvironmentObject var fontsManager: FontsManager
+    @StateObject private var viewModel: ReaderOptionsViewModel
+    
+    init(modelData: ModelData? = nil, fontsManager: FontsManager? = nil) {
+        let resolvedModel = modelData ?? ModelData.shared ?? ModelData()
+        let resolvedFonts = fontsManager ?? resolvedModel.fontsManager
+        self._viewModel = StateObject(wrappedValue: ReaderOptionsViewModel(modelData: resolvedModel, fontsManager: resolvedFonts))
+    }
 
-    @State private var optionsHelpFormat = false
-    @State private var optionsHelpReader = false
-    @State private var optionsHelpFont = false
-    
-    @State private var fontsFolderPresenting = false
-    @State private var fontsFolderPicked = [URL]()
-    @State private var fontsDetailPresenting = false
-    @State private var fontsCount = 0
-    @State private var fontsImportNotice = ""
-    
-    @State private var dismissAllCancellable: AnyCancellable?
-    
     var body: some View {
         List {
             Section(header: HStack {
                 Text("Preferred Book Format")
                 Spacer()
                 Button(action:{
-                    optionsHelpFormat = true
+                    viewModel.optionsHelpFormat = true
                 }) {
                     Image(systemName: "questionmark.circle")
                 }
             }) {
-                Picker("PreferredFormat", selection: preferredReaderTypeBinding()) {
+                Picker("PreferredFormat", selection: viewModel.preferredFormatBinding) {
                     ForEach(Format.allCases.dropFirst(), id: \.self) { format in
                         Text(format.rawValue).tag(format)
                     }
                 }
                 .pickerStyle(SegmentedPickerStyle())
-                .popover(isPresented: $optionsHelpFormat) {
+                .popover(isPresented: $viewModel.optionsHelpFormat) {
                     ReaderOptionsFormatHelpView()
                         .frame(maxWidth: 600, minHeight: 420)
                 }
@@ -49,20 +42,20 @@ struct ReaderOptionsView: View {
             
             Section {
                 VStack {
-                    ForEach(Format.allCases.filter { (modelData.formatReaderMap[$0]?.count ?? 0) > 0 }, id: \.self) { format in
+                    ForEach(Format.allCases.filter { (viewModel.modelData.formatReaderMap[$0]?.count ?? 0) > 0 }, id: \.self) { format in
                         HStack {
                             Text(format.rawValue)
                                 .frame(minWidth: 64, alignment: .leading)
                                 .padding([.leading], 8)
-                            Picker("Prefered", selection: preferredReaderTypeBinding(for: format)) {
-                                ForEach(modelData.formatReaderMap[format]!, id: \.self) { reader in
+                            Picker("Prefered", selection: viewModel.preferredReaderBinding(for: format)) {
+                                ForEach(viewModel.modelData.formatReaderMap[format]!, id: \.self) { reader in
                                     Text(reader.rawValue).tag(reader)
                                 }
                             }.pickerStyle(SegmentedPickerStyle())
                         }
                     }
                 }
-                .popover(isPresented: $optionsHelpReader) {
+                .popover(isPresented: $viewModel.optionsHelpReader) {
                     ReaderOptionsHelpView()
                 }
             } header: {
@@ -70,7 +63,7 @@ struct ReaderOptionsView: View {
                     Text("Prefered Reader")
                     Spacer()
                     Button(action: {
-                        optionsHelpReader = true
+                        viewModel.optionsHelpReader = true
                     }) {
                         Image(systemName: "questionmark.circle")
                     }
@@ -82,40 +75,33 @@ struct ReaderOptionsView: View {
                 Text("Custom Fonts for \(ReaderType.YabrEPUB.rawValue)")
                 Spacer()
                 Button(action:{
-                    optionsHelpFont = true
+                    viewModel.optionsHelpFont = true
                 }) {
                     Image(systemName: "questionmark.circle")
                 }
             }, footer: HStack {
-                Text(fontsImportNotice).font(.caption)
+                Text(viewModel.fontsImportNotice).font(.caption)
             }) {
                 HStack {
                     Text("Loaded")
-                    Text("\(fontsManager.userFontInfos.count)")
+                    Text("\(viewModel.fontsManager.userFontInfos.count)")
                     Text("font(s)")
                     Spacer()
                     
                     Button(action:{
-                        fontsCount = fontsManager.userFontInfos.count
-                        fontsDetailPresenting = true
+                        viewModel.startViewDetails()
                     }) {
                         Text("View")
                     }
-                    .disabled(fontsManager.userFontInfos.isEmpty)
+                    .disabled(viewModel.fontsManager.userFontInfos.isEmpty)
                     .buttonStyle(.borderless)
-                    .sheet(isPresented: $fontsDetailPresenting, onDismiss: {
-                        fontsDetailPresenting = false
-                        let newCount = fontsManager.userFontInfos.count
-                        let deletedCount = fontsCount - newCount
-                        if deletedCount > 0 {
-                            fontsImportNotice = "Deleted \(deletedCount) font(s)"
-                        }
-                        fontsCount = newCount
+                    .sheet(isPresented: $viewModel.fontsDetailPresenting, onDismiss: {
+                        viewModel.handleDetailsDismiss()
                     }) {
                         NavigationView {
                             List {
                                 ForEach(
-                                    fontsManager.userFontInfos.sorted {
+                                    viewModel.fontsManager.userFontInfos.sorted {
                                             ( $0.value.displayName ?? $0.key) < ( $1.value.displayName ?? $1.key)
                                         } , id: \.key ) { (fontId, fontInfo) in
                                     NavigationLink(destination: FontPreviewBuilder(fontId: fontId, fontInfo: fontInfo)) {
@@ -128,71 +114,28 @@ struct ReaderOptionsView: View {
                                             }
                                         }
                                     }
-                                }.onDelete(perform: removeFontRows)
+                                }.onDelete(perform: viewModel.removeFontRows)
                             }.navigationTitle("Favorite Fonts")
                         }
                     }
                 }
-                .popover(isPresented: $optionsHelpFont, attachmentAnchor: .point(.bottom), content: {
+                .popover(isPresented: $viewModel.optionsHelpFont, attachmentAnchor: .point(.bottom), content: {
                     ReaderOptionsFontHelpView()
                         .frame(maxWidth: 600, minHeight: 240)
                 })
                 
                 Button(action:{
-                    fontsCount = fontsManager.userFontInfos.count
-                    fontsFolderPresenting = true
+                    viewModel.startImport()
                 }) {
                     Text("Import Fonts")
                 }
-                .sheet(isPresented: $fontsFolderPresenting, onDismiss: {
-                    fontsFolderPresenting = false
+                .sheet(isPresented: $viewModel.fontsFolderPresenting, onDismiss: {
+                    viewModel.fontsFolderPresenting = false
                 }) {
-                    FontImportPicker(fontURLs: $fontsFolderPicked)
-                }
-                .onChange(of: fontsFolderPicked) { tmpURLs in
-                    let urls = tmpURLs.filter { $0 != FontImportPicker.FakeURL }
-                    urls.forEach {
-                        print("documentPicker \($0.absoluteString)")
-                    }
-                    fontsImportNotice = ""
-                    guard let imported = fontsManager.importCustomFonts(urls: urls) else {
-                        fontsImportNotice = "Error occured during import"
-                        return
-                    }
-                    fontsManager.reloadCustomFonts()
-                    let newCount = fontsManager.userFontInfos.count
-                    let deletedCount = fontsCount + imported.count - newCount
-                    if imported.count > 0 {
-                        fontsImportNotice = "Successfully imported \(imported.count) font(s)"
-                    }
-                    if deletedCount > 0 {
-                        if fontsImportNotice.count > 0 {
-                            fontsImportNotice = "\(fontsImportNotice), and deleted \(deletedCount) font(s)"
-                        } else {
-                            fontsImportNotice = "Deleted \(deletedCount) font(s)"
-                        }
-                    }
-                    if urls.count - imported.count > 0 {
-                        if fontsImportNotice.count > 0 {
-                            fontsImportNotice = "\(fontsImportNotice), and failed \(urls.count - imported.count) font(s)"
-                        } else {
-                            fontsImportNotice = "Failed \(urls.count - imported.count) font(s)"
-                        }
-                    }
-                    fontsCount = newCount
+                    FontImportPicker(fontURLs: $viewModel.fontsFolderPicked)
                 }
             }
             
-        }
-        .onAppear() {
-            dismissAllCancellable?.cancel()
-            dismissAllCancellable = modelData.dismissAllSubject.sink { _ in
-                fontsFolderPresenting = false
-                fontsDetailPresenting = false
-                optionsHelpFormat = false
-                optionsHelpReader = false
-                optionsHelpFont = false
-            }
         }
         .navigationTitle("Reader Options")
         .navigationBarTitleDisplayMode(.inline)
@@ -250,42 +193,13 @@ struct ReaderOptionsView: View {
             }.padding()
         }
     }
-    
-    private func preferredReaderTypeBinding(for format: Format) -> Binding<ReaderType> {
-        return .init(
-            get: {
-                modelData.getPreferredReader(for: format)
-            },
-            set: {
-                modelData.updatePreferredReader(for: format, with: $0)
-            })
-    }
-    
-    private func preferredReaderTypeBinding() -> Binding<Format>{
-        return .init(
-            get: {
-                return modelData.getPreferredFormat()
-            },
-            set: {
-                modelData.updatePreferredFormat(for: $0)
-            }
-        )
-    }
-    
-    
-    func removeFontRows(at offsets: IndexSet) {
-        fontsManager.removeCustomFonts(at: offsets)
-        fontsManager.reloadCustomFonts()
-    }
 }
 
 struct ReaderOptionsView_Previews: PreviewProvider {
     static var previews: some View {
         let modelData = ModelData()
         NavigationView {
-            ReaderOptionsView()
-                .environmentObject(modelData)
-                .environmentObject(modelData.fontsManager)
+            ReaderOptionsView(modelData: modelData, fontsManager: modelData.fontsManager)
         }.navigationViewStyle(StackNavigationViewStyle())
     }
 }

--- a/YetAnotherEBookReader/Views/SettingsView/ReaderOptions/ReaderOptionsViewModel.swift
+++ b/YetAnotherEBookReader/Views/SettingsView/ReaderOptions/ReaderOptionsViewModel.swift
@@ -1,0 +1,143 @@
+//
+//  ReaderOptionsViewModel.swift
+//  YetAnotherEBookReader
+//
+//  Created by Antigravity on 2026/6/13.
+//
+
+import Foundation
+import Combine
+import SwiftUI
+
+class ReaderOptionsViewModel: ObservableObject {
+    let modelData: ModelData
+    let fontsManager: FontsManager
+    
+    // Help & Sheet presentation state
+    @Published var optionsHelpFormat = false
+    @Published var optionsHelpReader = false
+    @Published var optionsHelpFont = false
+    
+    @Published var fontsFolderPresenting = false
+    @Published var fontsFolderPicked = [URL]()
+    @Published var fontsDetailPresenting = false
+    @Published var fontsCount = 0
+    @Published var fontsImportNotice = ""
+    
+    private var cancellables = Set<AnyCancellable>()
+    
+    init(modelData: ModelData, fontsManager: FontsManager) {
+        self.modelData = modelData
+        self.fontsManager = fontsManager
+        
+        setupBindings()
+    }
+    
+    private func setupBindings() {
+        // Observe dismissAllSubject to dismiss sheets/popovers
+        modelData.dismissAllSubject
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard let self = self else { return }
+                self.fontsFolderPresenting = false
+                self.fontsDetailPresenting = false
+                self.optionsHelpFormat = false
+                self.optionsHelpReader = false
+                self.optionsHelpFont = false
+            }
+            .store(in: &cancellables)
+            
+        // Observe changes to fontsFolderPicked to import fonts
+        $fontsFolderPicked
+            .dropFirst()
+            .sink { [weak self] tmpURLs in
+                guard let self = self else { return }
+                self.importFonts(from: tmpURLs)
+            }
+            .store(in: &cancellables)
+    }
+    
+    // MARK: - Format / Reader Preference Bindings
+    
+    var preferredFormatBinding: Binding<Format> {
+        Binding(
+            get: { [weak self] in
+                self?.modelData.getPreferredFormat() ?? .EPUB
+            },
+            set: { [weak self] in
+                self?.modelData.updatePreferredFormat(for: $0)
+            }
+        )
+    }
+    
+    func preferredReaderBinding(for format: Format) -> Binding<ReaderType> {
+        Binding(
+            get: { [weak self] in
+                self?.modelData.getPreferredReader(for: format) ?? .YabrEPUB
+            },
+            set: { [weak self] in
+                self?.modelData.updatePreferredReader(for: format, with: $0)
+            }
+        )
+    }
+    
+    // MARK: - Custom Fonts Management
+    
+    func startImport() {
+        fontsCount = fontsManager.userFontInfos.count
+        fontsFolderPresenting = true
+    }
+    
+    func startViewDetails() {
+        fontsCount = fontsManager.userFontInfos.count
+        fontsDetailPresenting = true
+    }
+    
+    func handleDetailsDismiss() {
+        fontsDetailPresenting = false
+        let newCount = fontsManager.userFontInfos.count
+        let deletedCount = fontsCount - newCount
+        if deletedCount > 0 {
+            fontsImportNotice = "Deleted \(deletedCount) font(s)"
+        }
+        fontsCount = newCount
+    }
+    
+    func removeFontRows(at offsets: IndexSet) {
+        fontsManager.removeCustomFonts(at: offsets)
+        fontsManager.reloadCustomFonts()
+    }
+    
+    private func importFonts(from tmpURLs: [URL]) {
+        let urls = tmpURLs.filter { $0 != FontImportPicker.FakeURL }
+        urls.forEach {
+            print("documentPicker \($0.absoluteString)")
+        }
+        fontsImportNotice = ""
+        guard let imported = fontsManager.importCustomFonts(urls: urls) else {
+            fontsImportNotice = "Error occurred during import"
+            return
+        }
+        fontsManager.reloadCustomFonts()
+        let newCount = fontsManager.userFontInfos.count
+        let deletedCount = fontsCount + imported.count - newCount
+        if imported.count > 0 {
+            fontsImportNotice = "Successfully imported \(imported.count) font(s)"
+        }
+        if deletedCount > 0 {
+            if fontsImportNotice.count > 0 {
+                fontsImportNotice = "\(fontsImportNotice), and deleted \(deletedCount) font(s)"
+            } else {
+                fontsImportNotice = "Deleted \(deletedCount) font(s)"
+            }
+        }
+        if urls.count - imported.count > 0 {
+            if fontsImportNotice.count > 0 {
+                fontsImportNotice = "\(fontsImportNotice), and failed \(urls.count - imported.count) font(s)"
+            } else {
+                fontsImportNotice = "Failed \(urls.count - imported.count) font(s)"
+            }
+        }
+        fontsCount = newCount
+    }
+}

--- a/YetAnotherEBookReader/Views/SettingsView/ServerView/AddModServerView.swift
+++ b/YetAnotherEBookReader/Views/SettingsView/ServerView/AddModServerView.swift
@@ -1,5 +1,5 @@
 //
-//  SettingsView.swift
+//  AddModServerView.swift
 //  YetAnotherEBookReader
 //
 //  Created by 京太郎 on 2021/3/31.
@@ -7,41 +7,15 @@
 
 import SwiftUI
 import OSLog
-import Combine
 
 struct AddModServerView: View {
     @EnvironmentObject var modelData: ModelData
     @Environment(\.openURL) var openURL
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
 
+    @ObservedObject var viewModel: ServerViewModel
     @Binding var server: CalibreServer
     @Binding var isActive: Bool
-    
-    // bindings for server editing
-    @State private var calibreServerUUID = UUID()
-    @State private var calibreServerName = ""
-    @State private var calibreServerUrl = ""
-    @State private var calibreServerUrlWelformed = ""
-    
-    @State private var calibreServerUrlPublic = ""
-    @State private var calibreServerSetPublicAddress = false
-    @State private var calibreServerNeedAuth = false
-    @State private var calibreUsername = ""
-    @State private var calibrePassword = ""
-    @State private var calibrePasswordVisible = false
-    
-    @State private var dataAction: String?
-    
-    @State private var libraryList = [String]()
-    
-    @State private var isProbing = false
-    
-    @State private var calibreServerInfo: CalibreServerInfo? = nil
-
-    @State private var serverCalibreInfoPresenting = false {
-        willSet { if newValue { modelData.presentingStack.append($serverCalibreInfoPresenting) } }
-        didSet { if oldValue { _ = modelData.presentingStack.popLast() } }
-    }
     
     @State private var localLibraryImportBooksPicked = [URL]()
     @State private var localLibraryImportPresenting = false {
@@ -49,34 +23,15 @@ struct AddModServerView: View {
         didSet { if oldValue { _ = modelData.presentingStack.popLast() } }
     }
     
-    @State private var updater = 0
-    
-    var defaultLog = Logger()
-    
-    @State private var alertItem: AlertItem?
-    
-    fileprivate func processInputAction() {
-        if server.baseUrl.isEmpty {
-            dataAction = "Add"
-            processUrlInputs()
-            addServerConfirmButtonAction()
-        } else {
-            dataAction = "Mod"
-            processUrlInputs()
-            modServerConfirmButtonAction()
-        }
-        self.serverCalibreInfoPresenting = true
-    }
-    
     var body: some View {
         Form {
             Section(
                 header: Text("Basic"),
-                footer: Text(calibreServerUrlWelformed)
+                footer: Text(viewModel.calibreServerUrlWelformed)
                         .font(.caption).foregroundColor(.red)
             ) {
-                textFieldView(label: "Name", title: "Name Your Server", text: $calibreServerName, original: server.name)
-                textFieldView(label: "URL", title: "Internal Server Address", text: $calibreServerUrl, original: server.baseUrl)
+                textFieldView(label: "Name", title: "Name Your Server", text: $viewModel.calibreServerName, original: server.name)
+                textFieldView(label: "URL", title: "Internal Server Address", text: $viewModel.calibreServerUrl, original: server.baseUrl)
                     .keyboardType(.URL)
                     .autocapitalization(.none)
                     .disableAutocorrection(true)
@@ -97,25 +52,25 @@ struct AddModServerView: View {
                     }
                 }
             ) {
-                Toggle("Internet Accessible", isOn: $calibreServerSetPublicAddress)
-                textFieldView(label: "Address", title: "Public Server Address", text: $calibreServerUrlPublic, original: server.publicUrl)
+                Toggle("Internet Accessible", isOn: $viewModel.calibreServerSetPublicAddress)
+                textFieldView(label: "Address", title: "Public Server Address", text: $viewModel.calibreServerUrlPublic, original: server.publicUrl)
                     .keyboardType(.URL)
                     .autocapitalization(.none)
                     .disableAutocorrection(true)
-                .disabled(!calibreServerSetPublicAddress)
+                .disabled(!viewModel.calibreServerSetPublicAddress)
             }
             Section(header: Text("Authentication")) {
-                Toggle("Require", isOn: $calibreServerNeedAuth)
+                Toggle("Require", isOn: $viewModel.calibreServerNeedAuth)
                 
                 Group {
-                    textFieldView(label: "Username", title: "Username", text: $calibreUsername, original: server.username)
+                    textFieldView(label: "Username", title: "Username", text: $viewModel.calibreUsername, original: server.username)
                         .keyboardType(.emailAddress)
                         .autocapitalization(.none)
                         .disableAutocorrection(true)
-                    secureFieldView(label: "Password", title: "", text: $calibrePassword, visible: $calibrePasswordVisible, original: server.password)
+                    secureFieldView(label: "Password", title: "", text: $viewModel.calibrePassword, visible: $viewModel.calibrePasswordVisible, original: server.password)
                         .autocapitalization(.none)
                         .disableAutocorrection(true)
-                }.disabled(!calibreServerNeedAuth)
+                }.disabled(!viewModel.calibreServerNeedAuth)
             }
             
             Section(
@@ -128,7 +83,7 @@ struct AddModServerView: View {
                         ProgressView()
                             .progressViewStyle(CircularProgressViewStyle())
                     } else {
-                        Text(calibreServerInfo?.errorMsg ?? "Unknown")
+                        Text(viewModel.calibreServerInfo?.errorMsg ?? "Unknown")
                     }
                     
                     if let reachable = modelData.isServerReachable(server: server, isPublic: false) {
@@ -145,34 +100,34 @@ struct AddModServerView: View {
                 },
                 footer: HStack(alignment: .center, spacing: 8) {
                     Spacer()
-                    Text("Got \(libraryList.count) Library(s) in Server")
+                    Text("Got \(viewModel.libraryList.count) Library(s) in Server")
                 }
             ) {
-                if libraryList.isEmpty {
+                if viewModel.libraryList.isEmpty {
                     Text("No Library")
                 } else {
-                    ForEach(libraryList, id: \.self) { name in
+                    ForEach(viewModel.libraryList, id: \.self) { name in
                         Text(name).font(.callout)
                     }
                 }
             }
         }
         .onAppear {
-            resetStates()
+            viewModel.resetStates(server: server)
         }
-        .sheet(isPresented: $serverCalibreInfoPresenting, onDismiss: {
-            dataAction = nil
-            disableProbeServerCancellable()
+        .sheet(isPresented: $viewModel.serverCalibreInfoPresenting, onDismiss: {
+            viewModel.dataAction = nil
+            viewModel.disableProbeServerCancellable()
         }, content: {
             serverCalibreInfoSheetView()
         })
-        .alert(item: $alertItem) { item in
+        .alert(item: $viewModel.alertItem) { item in
             if item.id == "Exist" {
                 return Alert(
-                    title: Text("\(dataAction ?? "") Server Errer"),
+                    title: Text("\(viewModel.dataAction ?? "") Server Error"),
                     message: Text(item.msg ?? ""),
                     dismissButton: .cancel(){
-                        alertItem = nil
+                        viewModel.alertItem = nil
                     }
                 )
             }
@@ -183,33 +138,32 @@ struct AddModServerView: View {
         .toolbar {
             ToolbarItem(placement: .confirmationAction) {
                 Button(action:{
-                    processInputAction()
+                    viewModel.processInputAction(server: server) {}
                 }) {
-                    if isProbing {
+                    if viewModel.isProbing {
                         ProgressView().progressViewStyle(.circular)
                     } else {
                         Image(systemName: "square.and.arrow.down")
                     }
                 }
-                .disabled(isProbing)
+                .disabled(viewModel.isProbing || modelData.isServerProbing(server: server))
             }
             ToolbarItem(placement: .cancellationAction) {
                 Button(action:{
-                    resetStates()
+                    viewModel.resetStates(server: server)
                 }) {
                     Image(systemName: "arrow.counterclockwise")
                 }
-                .disabled(isProbing || modelData.isServerProbing(server: server))
+                .disabled(viewModel.isProbing || modelData.isServerProbing(server: server))
             }
         }
-        
     }
     
     @ViewBuilder
     func serverCalibreInfoSheetView() -> some View {
         Form {
             Section(header: Text("Server Status")) {
-                if let serverInfo = calibreServerInfo {
+                if let serverInfo = viewModel.calibreServerInfo {
                     Text(serverInfo.errorMsg)
                 } else {
                     Text("Connecting")
@@ -218,40 +172,40 @@ struct AddModServerView: View {
             
             Section {
                 Button(action: {
-                    serverCalibreInfoPresenting = false
+                    viewModel.serverCalibreInfoPresenting = false
                 }) {
                     Text("Cancel")
                 }
                 
-                if calibreServerInfo?.errorMsg != "Success" {
+                if viewModel.calibreServerInfo?.errorMsg != "Success" {
                     Button {
-                        calibreServerInfo?.errorMsg = "Connecting..."
-                        processInputAction()
+                        viewModel.calibreServerInfo?.errorMsg = "Connecting..."
+                        viewModel.processInputAction(server: server) {}
                     } label: {
                         Text("Retry")
                     }
                 }
                 
                 Button(action: {
-                    if dataAction == "Add" {
-                        addServerConfirmed()
-                    } else if dataAction == "Mod" {
-                        modServerConfirmed()
+                    if viewModel.dataAction == "Add" {
+                        viewModel.addServerConfirmed(serverBinding: $server, isActiveBinding: $isActive)
+                    } else if viewModel.dataAction == "Mod" {
+                        viewModel.modServerConfirmed(serverBinding: $server, isActiveBinding: $isActive)
                     }
-                    serverCalibreInfoPresenting = false
+                    viewModel.serverCalibreInfoPresenting = false
                 }) {
-                    if dataAction == "Add" {
+                    if viewModel.dataAction == "Add" {
                         Text("Add")
-                    } else if dataAction == "Mod" {
+                    } else if viewModel.dataAction == "Mod" {
                         Text("Update")
                     } else {
                         Text("OK")
                     }
-                }.disabled(calibreServerInfo?.errorMsg != "Success")
+                }.disabled(viewModel.calibreServerInfo?.errorMsg != "Success")
             }
             
             Section(header: Text("Library List")) {
-                if let serverInfo = calibreServerInfo,
+                if let serverInfo = viewModel.calibreServerInfo,
                    serverInfo.errorMsg == "Success" {
                     ForEach(serverInfo.libraryMap.sorted(by: { $0.value < $1.value}), id: \.key) { libraryEntry in
                         HStack {
@@ -267,7 +221,6 @@ struct AddModServerView: View {
                 } else {
                     Text("Cannot Fetch Library List")
                 }
-                
             }
         }
     }
@@ -290,6 +243,7 @@ struct AddModServerView: View {
         }
         .buttonStyle(BorderlessButtonStyle())
     }
+    
     @ViewBuilder
     private func secureFieldView(label: String, title: String, text: Binding<String>, visible: Binding<Bool>, original: String) -> some View {
         HStack(spacing: 4) {
@@ -320,206 +274,6 @@ struct AddModServerView: View {
         }
         .buttonStyle(BorderlessButtonStyle())
     }
-    
-    private func resetStates() {
-        calibreServerName = server.name
-        calibreServerUrl = server.baseUrl
-        calibreUsername = server.username
-        calibrePassword = server.password
-        calibreServerUrlPublic = server.publicUrl
-        calibreServerSetPublicAddress = server.hasPublicUrl
-        calibreServerNeedAuth = server.hasAuth
-        libraryList = modelData.calibreLibraries.values.filter{ $0.server.id == server.id }.map{ $0.name }.sorted()
-    }
-    
-    private func canDeleteCurrentServer() -> Bool {
-        return !server.isLocal
-    }
-    
-    private func processUrlInputs() {
-        if calibreServerUrl != server.baseUrl {
-            if calibreServerUrl.contains("://") == false {
-                calibreServerUrl = "http://" + calibreServerUrl
-            }
-            if var components = URLComponents(string: calibreServerUrl) {
-                if components.scheme == nil {
-                    components.scheme = "http://"
-                }
-                if components.path == "" {
-                    components.path = "/"
-                }
-                if let s = components.string {
-                    calibreServerUrl = s
-                }
-            }
-        }
-        if calibreServerUrlPublic != server.publicUrl, var components = URLComponents(string: calibreServerUrlPublic) {
-            if components.scheme == nil {
-                components.scheme = "http://"
-            }
-            if components.path == "" {
-                components.path = "/"
-            }
-            if let s = components.string {
-                calibreServerUrlPublic = s
-            }
-        }
-    }
-    
-    private func addServerConfirmButtonAction() {
-        if calibreServerName.isEmpty {
-            if let url = URL(string: calibreServerUrl), let host = url.host {
-                calibreServerName = host
-            } else {
-                calibreServerName = "Unnamed"
-            }
-        }
-        
-        if let existingServer = modelData.calibreServers.values.first(where: { server in
-            server.baseUrl == calibreServerUrl
-            && server.username == calibreUsername
-            && server.removed == false
-        }) {
-            alertItem = AlertItem(id: "Exist", msg: "Conflict with \"\(existingServer.name)\"\nA server with the same address and username already exists")
-            return
-        }
-
-        calibreServerUUID = .init()
-        let calibreServer = CalibreServer(
-            uuid: calibreServerUUID,
-            name: calibreServerName,
-            baseUrl: calibreServerUrl,
-            hasPublicUrl: calibreServerSetPublicAddress,
-            publicUrl: calibreServerUrlPublic,
-            hasAuth: calibreServerNeedAuth,
-            username: calibreUsername,
-            password: calibrePassword
-        )
-        
-//        modelData.calibreServerUpdating = true
-//        if let task = modelData.calibreServerService.getServerLibraries(server: calibreServer) {
-//            dataLoadingTask = task
-//            serverCalibreInfoPresenting = true
-//        } else {
-//            alertItem = AlertItem(id: "Unexpected Error", msg: "Failed to connect to server")
-//        }
-        
-        performProbeServer(server: calibreServer)
-    }
-    
-    private func addServerConfirmed() {
-        guard let serverInfo = calibreServerInfo else { return }
-        
-        var newServer = serverInfo.server
-        newServer.defaultLibrary = serverInfo.defaultLibrary
-        
-        let libraries: [CalibreLibrary] = serverInfo.libraryMap
-            .sorted { $0.key < $1.key }
-            .map {
-                .init(
-                    server: serverInfo.server,
-                    key: $0,
-                    name: $1,
-                    autoUpdate: false,
-                    discoverable: true
-                )
-            }
-        
-        modelData.addServer(server: newServer, libraries: libraries)
-        if let url = URL(string: newServer.baseUrl) {
-            modelData.updateServerDSReaderHelper(
-                serverId: newServer.id,
-                dsreaderHelper: CalibreServerDSReaderHelper(
-                    port: (url.port ?? -1) + 1
-                ),
-                realm: modelData.realm)
-        }
-        
-        modelData.probeServersReachability(with: [newServer.id], updateLibrary: true, autoUpdateOnly: true)
-        
-        server = newServer
-        isActive = false
-    }
-    
-    private func modServerConfirmButtonAction() {
-        calibreServerUUID = server.uuid
-        let newServer = CalibreServer(
-            uuid: calibreServerUUID,
-            name: calibreServerName,
-            baseUrl: calibreServerUrl,
-            hasPublicUrl: calibreServerSetPublicAddress,
-            publicUrl: calibreServerUrlPublic,
-            hasAuth: calibreServerNeedAuth,
-            username: calibreUsername,
-            password: calibrePassword
-        )
-        
-            if let existingServer = modelData.calibreServers.values.first(where: { server in
-                server.uuid != newServer.uuid
-                && server.baseUrl == newServer.baseUrl
-                && server.username == newServer.username
-                && server.removed == false
-            }) {
-                alertItem = AlertItem(id: "Exist", msg: "Conflict with \"\(existingServer.name)\"\nA server with the same address and username already exists")
-                return
-            }
-
-//            modelData.calibreServerUpdating = true
-            
-//            if let task = modelData.calibreServerService.getServerLibraries(server: newServer) {
-//                dataLoadingTask = task
-//                serverCalibreInfoPresenting = true
-//            } else {
-//                alertItem = AlertItem(id: "Unexpected Error", msg: "Failed to connect to server")
-//            }
-            
-            performProbeServer(server: newServer)
-    }
-    
-    private func modServerConfirmed() {
-        guard let serverInfo = calibreServerInfo else {
-            alertItem = AlertItem(id: "Error", msg: "Unexpected Error")
-            return
-        }
-        
-        var newServer = serverInfo.request.server
-        newServer.defaultLibrary = serverInfo.defaultLibrary
-        newServer.removed = server.removed
-        
-        server = newServer
-        
-        isActive = false
-    }
-    
-    private func performProbeServer(server: CalibreServer) {
-        isProbing = true
-        Task {
-            let serverInfo = await modelData.probeServer(request: .init(server: server, isPublic: false, updateLibrary: false, autoUpdateOnly: true, incremental: true))
-            
-            await MainActor.run {
-                if let serverInfo = serverInfo {
-                    serverInfo.libraryMap.forEach { key, name in
-                        Task {
-                            await modelData.probeLibrary(request: .init(library: .init(server: serverInfo.request.server, key: key, name: name)))
-                        }
-                    }
-                    self.calibreServerInfo = serverInfo
-                }
-                isProbing = false
-            }
-        }
-    }
-    
-    private func disableProbeServerCancellable() {
-        self.calibreServerInfo = nil
-        self.isProbing = false
-    }
-}
-
-extension AddModServerView : AlertDelegate {
-    func alert(alertItem: AlertItem) {
-        self.alertItem = alertItem
-    }
 }
 
 struct AddModServerView_Previews: PreviewProvider {
@@ -529,8 +283,9 @@ struct AddModServerView_Previews: PreviewProvider {
     @State static private var addServerActive = false
 
     static var previews: some View {
+        let viewModel = ServerViewModel(modelData: modelData, server: server)
         NavigationView {
-            AddModServerView(server: $server, isActive: $addServerActive)
+            AddModServerView(viewModel: viewModel, server: $server, isActive: $addServerActive)
                 .environmentObject(modelData)
                 .onAppear() {
                     modelData.calibreServers[server.id] = server

--- a/YetAnotherEBookReader/Views/SettingsView/ServerView/LibraryDetailView.swift
+++ b/YetAnotherEBookReader/Views/SettingsView/ServerView/LibraryDetailView.swift
@@ -6,45 +6,38 @@
 //
 
 import SwiftUI
-import RealmSwift
 
 struct LibraryDetailView: View {
-    @EnvironmentObject var modelData: ModelData
+    @StateObject private var viewModel: LibraryViewModel
 
-    @ObservedResults(CalibreBookRealm.self, configuration: ModelData.shared?.realmConf) var books
-    
-    var library: CalibreLibrary
-    @ObservedRealmObject var libraryRealm: CalibreLibraryRealm
+    init(modelData: ModelData, library: CalibreLibrary) {
+        _viewModel = StateObject(wrappedValue: LibraryViewModel(modelData: modelData, library: library))
+    }
 
-    @State private var activityListViewPresenting = false
-    @State private var updater = 0
-
-    @State private var isStoreActive = false
-    
     var body: some View {
         Form {
             Section(header: Text("Browsable")) {
-                Toggle("Include in Discover", isOn: $libraryRealm.discoverable)
+                Toggle("Include in Discover", isOn: $viewModel.discoverable)
                 
-                Toggle("Available when Offline", isOn: $libraryRealm.autoUpdate)
+                Toggle("Available when Offline", isOn: $viewModel.autoUpdate)
             }
             
             Section(header: Text("Troubleshooting")) {
                 NavigationLink(
-                    destination: ActivityList(viewModel: ActivityListViewModel(modelData: modelData, libraryId: library.id, bookId: nil), presenting: Binding<Bool>(get: { false }, set:{_ in }))
+                    destination: ActivityList(viewModel: ActivityListViewModel(modelData: viewModel.modelData, libraryId: viewModel.library.id, bookId: nil), presenting: Binding<Bool>(get: { false }, set:{_ in }))
                 ) {
                     Text("Activity Logs")
                 }
-                if let err = modelData.librarySyncStatus[library.id]?.err, err.isEmpty == false {
+                if viewModel.errCount > 0 {
                     NavigationLink {
                         List {
-                            ForEach(err.map { $0 }.sorted(), id: \.self) { bookId in
+                            ForEach(viewModel.failedBookIds, id: \.self) { bookId in
                                 HStack {
                                     Text(bookId.description)
                                     
-                                    if let obj = modelData.getBookRealm(forPrimaryKey: CalibreBookRealm.PrimaryKey(serverUUID: library.server.uuid.uuidString, libraryName: library.name, id: bookId.description)) {
+                                    if let title = viewModel.failedBookTitles[bookId] {
                                         Spacer()
-                                        Text(obj.title)
+                                        Text(title)
                                     }
                                 }
                             }
@@ -53,16 +46,16 @@ struct LibraryDetailView: View {
                         Text("Book IDs Failed to Sync")
                     }
                 }
-                if let del = modelData.librarySyncStatus[library.id]?.del, del.isEmpty == false {
+                if viewModel.delCount > 0 {
                     NavigationLink {
                         List {
-                            ForEach(del.map { $0 }.sorted(), id: \.self) { bookId in
+                            ForEach(viewModel.deletedBookIds, id: \.self) { bookId in
                                 HStack {
                                     Text(bookId.description)
                                     
-                                    if let obj = modelData.getBookRealm(forPrimaryKey: CalibreBookRealm.PrimaryKey(serverUUID: library.server.uuid.uuidString, libraryName: library.name, id: bookId.description)) {
+                                    if let title = viewModel.deletedBookTitles[bookId] {
                                         Spacer()
-                                        Text(obj.title)
+                                        Text(title)
                                     }
                                 }
                             }
@@ -76,34 +69,27 @@ struct LibraryDetailView: View {
             #if DEBUG
             Section {
                 Button("Reset Books") {
-                    try! modelData.realm.write {
-                        modelData.realm.objects(CalibreBookRealm.self).forEach {
-                            $0.lastModified = .init(timeIntervalSince1970: 0)
-                            $0.lastSynced = .init(timeIntervalSince1970: 0)
-                            $0.title = "__RESET__"
-                        }
-                    }
+                    viewModel.resetBooks()
                 }
             } header: {
                 Text("OP")
             }
             
             Section {
-                Text("isSync: \((modelData.librarySyncStatus[library.id]?.isSync ?? false) ? "true" : "false")")
-                Text("isUpd: \((modelData.librarySyncStatus[library.id]?.isUpd ?? false) ? "true" : "false")")
-                Text("isError: \((modelData.librarySyncStatus[library.id]?.isError ?? false) ? "true" : "false")")
-                Text("MSG: \(modelData.librarySyncStatus[library.id]?.msg ?? "nil")")
-                Text("CNT: \(modelData.librarySyncStatus[library.id]?.cnt ?? -1)")
-                Text("UPD: \(modelData.librarySyncStatus[library.id]?.upd.count ?? -1)")
-                Text("DEL: \(modelData.librarySyncStatus[library.id]?.del.count ?? -1)")
-                Text("ERR: \(modelData.librarySyncStatus[library.id]?.err.count ?? -1)")
+                Text("isSync: \(viewModel.isSync ? "true" : "false")")
+                Text("isUpd: \(viewModel.isUpd ? "true" : "false")")
+                Text("isError: \(viewModel.isError ? "true" : "false")")
+                Text("MSG: \(viewModel.msg)")
+                Text("CNT: \(viewModel.cnt)")
+                Text("UPD: \(viewModel.updCount)")
+                Text("DEL: \(viewModel.delCount)")
+                Text("ERR: \(viewModel.errCount)")
             } header: {
                 Text("DEBUG")
             }
             #endif
         }
     }
-
 }
 
 struct LibraryDetailView_Previews: PreviewProvider {
@@ -111,17 +97,12 @@ struct LibraryDetailView_Previews: PreviewProvider {
 
     @State static private var library = modelData.calibreLibraries.values.first ?? .init(server: .init(uuid: .init(), name: "default", baseUrl: "default", hasPublicUrl: true, publicUrl: "default", hasAuth: true, username: "default", password: "default"), key: "Default", name: "Default")
 
-    @State static private var discoverable = false
-    @State static private var autoUpdate = false
-    
     static var previews: some View {
-        let libraryRealm = modelData.realm.object(ofType: CalibreLibraryRealm.self, forPrimaryKey: library.id) ?? CalibreLibraryRealm()
         return NavigationView {
             LibraryDetailView(
-                library: library,
-                libraryRealm: libraryRealm
+                modelData: modelData,
+                library: library
             )
-            .environmentObject(modelData)
         }
         .navigationViewStyle(StackNavigationViewStyle())
     }

--- a/YetAnotherEBookReader/Views/SettingsView/ServerView/LibraryViewModel.swift
+++ b/YetAnotherEBookReader/Views/SettingsView/ServerView/LibraryViewModel.swift
@@ -1,0 +1,163 @@
+//
+//  LibraryViewModel.swift
+//  YetAnotherEBookReader
+//
+//  Created by Antigravity on 2026/6/12.
+//
+
+import Foundation
+import Combine
+import RealmSwift
+
+class LibraryViewModel: ObservableObject {
+    let modelData: ModelData
+    let library: CalibreLibrary
+    
+    @Published var discoverable: Bool = false
+    @Published var autoUpdate: Bool = false
+    
+    // UI state derived from modelData.librarySyncStatus
+    @Published var isSync = false
+    @Published var isUpd = false
+    @Published var isError = false
+    @Published var msg = "nil"
+    @Published var cnt = -1
+    @Published var updCount = -1
+    @Published var delCount = -1
+    @Published var errCount = -1
+    
+    @Published var failedBookTitles: [Int32: String] = [:]
+    @Published var deletedBookTitles: [Int32: String] = [:]
+    
+    @Published var failedBookIds: [Int32] = []
+    @Published var deletedBookIds: [Int32] = []
+    
+    private var cancellables = Set<AnyCancellable>()
+    private var libraryRealmToken: NotificationToken?
+    
+    init(modelData: ModelData, library: CalibreLibrary) {
+        self.modelData = modelData
+        self.library = library
+        
+        setupBindings()
+    }
+    
+    deinit {
+        libraryRealmToken?.invalidate()
+    }
+    
+    private func setupBindings() {
+        // Fetch initially
+        if let realm = try? Realm(configuration: modelData.realmConf),
+           let realmLib = realm.object(ofType: CalibreLibraryRealm.self, forPrimaryKey: library.id) {
+            self.discoverable = realmLib.discoverable
+            self.autoUpdate = realmLib.autoUpdate
+            
+            // Observe changes to the Realm object
+            libraryRealmToken = realmLib.observe { [weak self] change in
+                guard let self = self else { return }
+                switch change {
+                case .change(let object, let properties):
+                    for property in properties {
+                        if property.name == "discoverable", let val = property.newValue as? Bool {
+                            DispatchQueue.main.async { self.discoverable = val }
+                        }
+                        if property.name == "autoUpdate", let val = property.newValue as? Bool {
+                            DispatchQueue.main.async { self.autoUpdate = val }
+                        }
+                    }
+                case .error(let error):
+                    print("Error observing CalibreLibraryRealm: \(error)")
+                case .deleted:
+                    break
+                }
+            }
+        }
+        
+        // Listen to UI changes and save to Realm
+        $discoverable
+            .dropFirst()
+            .removeDuplicates()
+            .sink { [weak self] newValue in
+                guard let self = self else { return }
+                self.updateRealmField { $0.discoverable = newValue }
+            }
+            .store(in: &cancellables)
+            
+        $autoUpdate
+            .dropFirst()
+            .removeDuplicates()
+            .sink { [weak self] newValue in
+                guard let self = self else { return }
+                self.updateRealmField { $0.autoUpdate = newValue }
+            }
+            .store(in: &cancellables)
+            
+        // Observe modelData.librarySyncStatus
+        modelData.$librarySyncStatus
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] statusMap in
+                guard let self = self else { return }
+                let status = statusMap[self.library.id]
+                self.isSync = status?.isSync ?? false
+                self.isUpd = status?.isUpd ?? false
+                self.isError = status?.isError ?? false
+                self.msg = status?.msg ?? "nil"
+                self.cnt = status?.cnt ?? -1
+                self.updCount = status?.upd.count ?? -1
+                self.delCount = status?.del.count ?? -1
+                self.errCount = status?.err.count ?? -1
+                
+                self.failedBookIds = status?.err.map { $0 }.sorted() ?? []
+                self.deletedBookIds = status?.del.map { $0 }.sorted() ?? []
+                
+                self.resolveBookTitles()
+            }
+            .store(in: &cancellables)
+    }
+    
+    private func updateRealmField(writeBlock: @escaping (CalibreLibraryRealm) -> Void) {
+        guard let realm = try? Realm(configuration: modelData.realmConf) else { return }
+        if let realmLib = realm.object(ofType: CalibreLibraryRealm.self, forPrimaryKey: library.id) {
+            try? realm.write {
+                writeBlock(realmLib)
+            }
+        }
+    }
+    
+    private func resolveBookTitles() {
+        let serverUUID = library.server.uuid.uuidString
+        let libraryName = library.name
+        
+        var tempFailed: [Int32: String] = [:]
+        for bookId in failedBookIds {
+            let primaryKey = CalibreBookRealm.PrimaryKey(serverUUID: serverUUID, libraryName: libraryName, id: bookId.description)
+            if let obj = modelData.getBookRealm(forPrimaryKey: primaryKey) {
+                tempFailed[bookId] = obj.title
+            }
+        }
+        self.failedBookTitles = tempFailed
+        
+        var tempDeleted: [Int32: String] = [:]
+        for bookId in deletedBookIds {
+            let primaryKey = CalibreBookRealm.PrimaryKey(serverUUID: serverUUID, libraryName: libraryName, id: bookId.description)
+            if let obj = modelData.getBookRealm(forPrimaryKey: primaryKey) {
+                tempDeleted[bookId] = obj.title
+            }
+        }
+        self.deletedBookTitles = tempDeleted
+    }
+    
+    #if DEBUG
+    func resetBooks() {
+        guard let realm = try? Realm(configuration: modelData.realmConf) else { return }
+        try? realm.write {
+            realm.objects(CalibreBookRealm.self).forEach {
+                $0.lastModified = .init(timeIntervalSince1970: 0)
+                $0.lastSynced = .init(timeIntervalSince1970: 0)
+                $0.title = "__RESET__"
+            }
+        }
+    }
+    #endif
+}

--- a/YetAnotherEBookReader/Views/SettingsView/ServerView/ServerDetailView.swift
+++ b/YetAnotherEBookReader/Views/SettingsView/ServerView/ServerDetailView.swift
@@ -7,7 +7,6 @@
 
 import SwiftUI
 import Combine
-import RealmSwift
 
 struct ServerDetailView: View {
     @EnvironmentObject var modelData: ModelData

--- a/YetAnotherEBookReader/Views/SettingsView/ServerView/ServerDetailView.swift
+++ b/YetAnotherEBookReader/Views/SettingsView/ServerView/ServerDetailView.swift
@@ -12,27 +12,22 @@ struct ServerDetailView: View {
     @EnvironmentObject var modelData: ModelData
 
     @Binding var server: CalibreServer
-    @State private var selectedLibrary: String? = nil
+    @StateObject private var viewModel: ServerViewModel
     
     @State private var modServerActive = false
     @State private var dshelperActive = false
-    
-    @State private var libraryList = [String]()
-
-    @State private var syncingLibrary = false
-    @State private var syncLibraryColumnsCancellable: AnyCancellable? = nil
-    
     @State private var updater = 0
     
-    @State private var libraryRestoreListActive = false
-    @State private var libraryRestoreListEditMode = EditMode.active
-    @State private var libraryRestoreListSelection = Set<String>()
+    init(server: Binding<CalibreServer>) {
+        self._server = server
+        self._viewModel = StateObject(wrappedValue: ServerViewModel(modelData: ModelData.shared ?? ModelData(), server: server.wrappedValue))
+    }
     
     var body: some View {
         Form {
             Section(header: Text("Options")) {
                 NavigationLink(
-                    destination: AddModServerView(server: $server, isActive: $modServerActive)
+                    destination: AddModServerView(viewModel: viewModel, server: $server, isActive: $modServerActive)
                         .navigationTitle("Modify: \(server.name)"),
                     isActive: $modServerActive,
                     label: {
@@ -42,7 +37,7 @@ struct ServerDetailView: View {
                 .isDetailLink(false)
                 
                 NavigationLink(
-                    destination: ServerOptionsDSReaderHelper(server: $server, updater: $updater),
+                    destination: ServerOptionsDSReaderHelper(viewModel: viewModel, server: $server, updater: $updater),
                     isActive: $dshelperActive,
                     label: {
                         Text("DSReader Helper")
@@ -52,36 +47,21 @@ struct ServerDetailView: View {
             }
             
             Section(header: librarySectionHeader()) {
-                ForEach(libraryList.compactMap { modelData.calibreLibraries[$0] }, id: \.self) { library in
+                ForEach(viewModel.libraryList.compactMap { modelData.calibreLibraries[$0] }, id: \.self) { library in
                     NavigationLink(
                         destination: libraryEntryDestination(library: library),
                         tag: library.id,
-                        selection: $selectedLibrary) {
+                        selection: $viewModel.selectedLibrary) {
                         libraryRowBuilder(library: library)
                     }
                 }.onDelete(perform: { indexSet in
-                    let deletedLibraryIds = indexSet.map { libraryList[$0] }
-                    deletedLibraryIds.forEach { libraryId in
-                        self.modelData.hideLibrary(libraryId: libraryId)
-                        
-                        guard self.modelData.librarySyncStatus[libraryId]?.isSync != true else { return }
-                        
-                        guard let library = self.modelData.calibreLibraries[libraryId]
-                        else { return }
-                        
-                        self.modelData.calibreUpdatedSubject.send(.library(library))
-                        
-                        Task {
-                            await self.modelData.removeLibrary(library: library)
-                        }
-                    }
-                    updateLibraryList()
+                    viewModel.deleteLibrary(at: indexSet)
                 })
             }
             
             NavigationLink(
                 destination: libraryRestoreHiddenView(),
-                isActive: $libraryRestoreListActive,
+                isActive: $viewModel.libraryRestoreListActive,
                 label: {
                     Text("Restore Hidden Libraries")
                 }
@@ -93,15 +73,15 @@ struct ServerDetailView: View {
         }
         .navigationTitle(server.name)
         .onAppear() {
-            updateLibraryList()
+            viewModel.updateLibraryList()
         }
-        .onChange(of: modelData.calibreLibraries, perform: { value in
-            updateLibraryList()
+        .onChange(of: modelData.calibreLibraries, perform: { _ in
+            viewModel.updateLibraryList()
         })
         .toolbar {
             ToolbarItem(placement: .cancellationAction) {
                 Button(action: {
-                    modelData.removeDeleteBooksFromServer(server: server)
+                    viewModel.removeDeleteBooksFromServer(server: server)
                 }) {
                     Image(systemName: "xmark.bin")
                 }.disabled(
@@ -112,14 +92,11 @@ struct ServerDetailView: View {
             }
             ToolbarItem(placement: .confirmationAction) {
                 Button(action: {
-                    modelData.probeServersReachability(with: [server.id], updateLibrary: true, autoUpdateOnly: true, incremental: false)
+                    viewModel.probeReachability(server: server)
                 }) {
                     Image(systemName: "arrow.triangle.2.circlepath")
-                }.disabled(syncingLibrary)
+                }.disabled(viewModel.syncingLibrary)
             }
-        }
-        .onDisappear() {
-            syncLibraryColumnsCancellable?.cancel()
         }
     }
 
@@ -138,19 +115,15 @@ struct ServerDetailView: View {
     
     @ViewBuilder
     private func libraryEntryDestination(library: CalibreLibrary) -> some View {
-        if let libraryRealm = modelData.realm.object(ofType: CalibreLibraryRealm.self, forPrimaryKey: library.id) {
-            LibraryDetailView(
-                library: library,
-                libraryRealm: libraryRealm
-            ).navigationTitle(library.name)
-        } else {
-            Text("Library not found in database.")
-        }
+        LibraryDetailView(
+            modelData: modelData,
+            library: library
+        ).navigationTitle(library.name)
     }
     
     @ViewBuilder
     private func libraryRestoreHiddenView() -> some View {
-        List(selection: $libraryRestoreListSelection) {
+        List(selection: $viewModel.libraryRestoreListSelection) {
             ForEach(
                 modelData.calibreLibraries.filter { $0.value.hidden && $0.value.server.id == server.id }.map{$0.value}.sorted{$0.id < $1.id},
                 id: \.id
@@ -160,26 +133,18 @@ struct ServerDetailView: View {
             }
         }
         .navigationTitle(Text("Restore Hidden Libraries"))
-        .environment(\.editMode, $libraryRestoreListEditMode)
+        .environment(\.editMode, .constant(.active))
         .toolbar {
             ToolbarItem(placement: .confirmationAction) {
                 Button(action:{
-                    libraryRestoreListSelection.forEach {
-                        modelData.restoreLibrary(libraryId: $0)
-                        if let library =  self.modelData.calibreLibraries[$0],
-                           library.discoverable {
-                            self.modelData.calibreUpdatedSubject.send(.library(library))
-                        }
-                    }
-                    updater += 1
-                    libraryRestoreListActive.toggle()
+                    viewModel.restoreSelectedLibraries(updater: $updater)
                 }) {
                     Image(systemName: "checkmark.circle")
-                }.disabled(libraryRestoreListSelection.isEmpty)
+                }.disabled(viewModel.libraryRestoreListSelection.isEmpty)
             }
         }
         .onAppear {
-            libraryRestoreListSelection.removeAll()
+            viewModel.libraryRestoreListSelection.removeAll()
         }
     }
     
@@ -265,16 +230,6 @@ struct ServerDetailView: View {
             }
         }
     }
-
-    private func updateLibraryList() {
-        libraryList = modelData.calibreLibraries.values.filter{ library in
-            library.server.id == server.id && library.hidden == false
-        }
-        .sorted{ $0.name < $1.name }
-        .map { $0.id }
-        
-    }
-    
 }
 
 struct ServerDetailView_Previews: PreviewProvider {

--- a/YetAnotherEBookReader/Views/SettingsView/ServerView/ServerDetailView.swift
+++ b/YetAnotherEBookReader/Views/SettingsView/ServerView/ServerDetailView.swift
@@ -170,29 +170,35 @@ struct ServerDetailView: View {
             
             Spacer()
             VStack(alignment: .trailing) {
-                if let cnt = modelData.librarySyncStatus[library.id]?.cnt {
-                    Text("\(cnt) books")
-                } else if let msg = modelData.librarySyncStatus[library.id]?.msg {
-                    Text("processing\n\(msg)")
-                } else if modelData.librarySyncStatus[library.id]?.isSync == true {
-                    Text("processing ...")
-                }
-                if modelData.librarySyncStatus[library.id]?.isError == true {
-                    Text(modelData.librarySyncStatus[library.id]?.msg ?? "Status Unknown")
-                } else if let cnt = modelData.librarySyncStatus[library.id]?.cnt,
-                          let upd = modelData.librarySyncStatus[library.id]?.upd {
-                    if upd.count > 0, cnt > upd.count {
-                        if modelData.librarySyncStatus[library.id]?.isUpd == true {
-                            Text("Pulling book info, \(upd.count) to go")
+                if let status = modelData.librarySyncStatus[library.id] {
+                    if status.isSync {
+                        if let msg = status.msg {
+                            Text("processing\n\(msg)")
                         } else {
-                            Text("\(upd.count) entries not up to date")
+                            Text("processing ...")
                         }
-                    } else if let del = modelData.librarySyncStatus[library.id]?.del, del.count > 0 {
-                        Text("\(del.count) entries deleted from server")
-                            .foregroundColor(.red)
+                    } else if status.isError {
+                        Text(status.msg ?? "Status Unknown")
+                    } else {
+                        // Success state or finished syncing
+                        if let cnt = status.cnt {
+                            Text("\(cnt) books")
+                        } else if let msg = status.msg {
+                            Text(msg)
+                        }
+                        
+                        if status.isUpd && status.upd.count > 0 {
+                            Text("Pulling book info, \(status.upd.count) to go")
+                        } else if status.upd.count > 0 {
+                            Text("\(status.upd.count) entries not up to date")
+                        }
+                        
+                        if status.del.count > 0 {
+                            Text("\(status.del.count) entries deleted from server")
+                                .foregroundColor(.red)
+                        }
                     }
-                }
-                else if modelData.librarySyncStatus[library.id]?.isSync == false {
+                } else {
                     Text("Insufficient Info")
                 }
             }.font(.caption2)

--- a/YetAnotherEBookReader/Views/SettingsView/ServerView/ServerOptionsDSReaderHelper.swift
+++ b/YetAnotherEBookReader/Views/SettingsView/ServerView/ServerOptionsDSReaderHelper.swift
@@ -1,5 +1,5 @@
 //
-//  LibraryOptionsDSReaderHelper.swift
+//  ServerOptionsDSReaderHelper.swift
 //  YetAnotherEBookReader
 //
 //  Created by 京太郎 on 2021/11/22.
@@ -12,28 +12,14 @@ struct ServerOptionsDSReaderHelper: View {
     @EnvironmentObject var modelData: ModelData
     @Environment(\.openURL) var openURL
 
+    @ObservedObject var viewModel: ServerViewModel
     @Binding var server: CalibreServer
-    @State var dsreaderHelperServer = CalibreServerDSReaderHelper(port: 0)
     
-    @State private var portStr = ""
-    @State private var configurationData: Data? = nil
-    @State private var configuration: CalibreDSReaderHelperConfiguration? = nil
-    
-    @State private var refreshCancellable: AnyCancellable? = nil
-
-    @State private var helperStatus: String? = nil
-    
-    @State private var configAlertItem: AlertItem?
-
     @State private var dictionaryViewerDetails = false
     @State private var countPagesDetails = false
     @State private var goodreadsSyncDetails = false
     
-    @State private var dsreaderHelperInstructionPresenting = false
-
     @Binding var updater: Int
-    
-    @State private var serverAddedCancellable: AnyCancellable?
     
     var body: some View {
         ZStack {
@@ -44,29 +30,14 @@ struct ServerOptionsDSReaderHelper: View {
                         
                         Spacer()
                         
-                        TextField("Plugin Service Port", text: $portStr)
+                        TextField("Plugin Service Port", text: $viewModel.portStr)
                             .frame(idealWidth: 80, maxWidth: 80)
                             .multilineTextAlignment(.center)
                             .keyboardType(.numberPad)
-                            .onReceive(Just(portStr)) { newValue in
-                                let filtered = newValue.filter { "0123456789".contains($0) }
-                                if let num = Int(filtered), num != dsreaderHelperServer.port {
-                                    if num > 65535 {
-                                        dsreaderHelperServer.port = 65535
-                                    } else if num < 1024 {
-                                        dsreaderHelperServer.port = 1024
-                                    } else {
-                                        dsreaderHelperServer.port = num
-                                    }
-                                }
-                            }
-                            .onChange(of: dsreaderHelperServer.port, perform: { value in
-                                portStr = value.description
-                            })
                         
                         Button(action:{
-                            if dsreaderHelperServer.port > 1024 {
-                                portStr = (dsreaderHelperServer.port-1).description
+                            if viewModel.dsreaderHelperServer.port > 1024 {
+                                viewModel.portStr = (viewModel.dsreaderHelperServer.port - 1).description
                             }
                         }) {
                             Image(systemName: "minus")
@@ -74,8 +45,8 @@ struct ServerOptionsDSReaderHelper: View {
                         .buttonStyle(.borderless)
                         
                         Button(action:{
-                            if dsreaderHelperServer.port < 65535 {
-                                portStr = (dsreaderHelperServer.port+1).description
+                            if viewModel.dsreaderHelperServer.port < 65535 {
+                                viewModel.portStr = (viewModel.dsreaderHelperServer.port + 1).description
                             }
                         }) {
                             Image(systemName: "plus")
@@ -88,7 +59,7 @@ struct ServerOptionsDSReaderHelper: View {
                     NavigationLink(
                         destination: List {
                             ForEach (
-                                configuration?.count_pages_prefs?.library_config?.map {
+                                viewModel.configuration?.count_pages_prefs?.library_config?.map {
                                     (key: $0.key, value: $0.value) }.sorted { $0.key < $1.key } ?? [], id: \.key
                             ) { key, value in
                                 Section(header: Text("Library \(key)")) {
@@ -108,7 +79,7 @@ struct ServerOptionsDSReaderHelper: View {
                         HStack {
                             Text("Count Pages")
                             Spacer()
-                            if configuration?.count_pages_prefs?.library_config?.count ?? 0 > 0 {
+                            if viewModel.configuration?.count_pages_prefs?.library_config?.count ?? 0 > 0 {
                                 Text("detected")
                             } else {
                                 Text("missing")
@@ -119,7 +90,7 @@ struct ServerOptionsDSReaderHelper: View {
                     NavigationLink(
                         destination: List{
                             ForEach (
-                                configuration?.goodreads_sync_prefs?.plugin_prefs.Users.map {
+                                viewModel.configuration?.goodreads_sync_prefs?.plugin_prefs.Users.map {
                                     (key: $0.key, value: $0.value) }.sorted { $0.key < $1.key } ?? [], id: \.key
                             ) { user_entry in
                                 Section(header: Text("Profile \(user_entry.key)")) {
@@ -133,7 +104,7 @@ struct ServerOptionsDSReaderHelper: View {
                         HStack {
                             Text("Goodreads Sync")
                             Spacer()
-                            if configuration?.goodreads_sync_prefs?.plugin_prefs.Users.count ?? 0 > 0 {
+                            if viewModel.configuration?.goodreads_sync_prefs?.plugin_prefs.Users.count ?? 0 > 0 {
                                 Text("detected")
                             } else {
                                 Text("missing")
@@ -145,7 +116,7 @@ struct ServerOptionsDSReaderHelper: View {
                     HStack {
                         Text("Dictionary Viewer")
                         Spacer()
-                        if let options = configuration?.dsreader_helper_prefs?.plugin_prefs.Options,
+                        if let options = viewModel.configuration?.dsreader_helper_prefs?.plugin_prefs.Options,
                            options.dictViewerEnabled,
                            options.dictViewerLibraryName.count > 0 {
                             Text("Enabled\nUsing Library \(options.dictViewerLibraryName)")
@@ -158,9 +129,9 @@ struct ServerOptionsDSReaderHelper: View {
                     }
                 }
             }
-            .disabled(helperStatus != nil)
+            .disabled(viewModel.helperStatus != nil)
             
-            if let helperStatus = helperStatus {
+            if let helperStatus = viewModel.helperStatus {
                 VStack {
                     Text(helperStatus)
                         .padding()
@@ -171,35 +142,37 @@ struct ServerOptionsDSReaderHelper: View {
         .toolbar {
             ToolbarItem(placement: .confirmationAction) {
                 Button(action:{
-                    connect()
+                    viewModel.connectDSReader(server: server)
                 }) {
                     Image(systemName: "square.and.arrow.down")
                 }
             }
             ToolbarItem(placement: .confirmationAction) {
                 Button(action:{
-                    dsreaderHelperInstructionPresenting = true
+                    viewModel.dsreaderHelperInstructionPresenting = true
                 }) {
                     Image(systemName: "questionmark.circle")
                 }
             }
         }
         .onAppear() {
-            setStates()
+            viewModel.setDSReaderStates(server: server)
         }
         .onChange(of: updater) { _ in
-            setStates()
+            viewModel.setDSReaderStates(server: server)
         }
-        .alert(item: $configAlertItem) { item in
+        .alert(item: $viewModel.configAlertItem) { item in
             if item.id == "updateConfigAlert" {
                 return Alert(
                     title: Text("Use DSReader Helper Config?"),
                     message: Text("Successfully downloaded helper plugin configurations from server, update local settings?"),
-                    primaryButton: .default(Text("Update"), action: update),
+                    primaryButton: .default(Text("Update"), action: {
+                        viewModel.updateDSReaderHelperConfig(server: server)
+                    }),
                     secondaryButton: .cancel({
-                        dsreaderHelperServer.configuration = nil
-                        dsreaderHelperServer.configurationData = nil
-                        helperStatus = nil
+                        viewModel.dsreaderHelperServer.configuration = nil
+                        viewModel.dsreaderHelperServer.configurationData = nil
+                        viewModel.helperStatus = nil
                     }))
             }
             if item.id == "failedParseConfigAlert" {
@@ -211,133 +184,28 @@ struct ServerOptionsDSReaderHelper: View {
             }
             if item.id == "failedConnectConfigAlert" {
                 return Alert(
-                    title: Text("DSReader Helper Unavaiable"),
-                    message: Text("Have you installed DSReader Helper plugin on calibre server?\nThe plugin will greatly enhance this App's abilty to interact with services provided by your favorite calibre plugins. We highly recommend you look into it."),
+                    title: Text("DSReader Helper Unavailable"),
+                    message: Text("Have you installed DSReader Helper plugin on calibre server?\nThe plugin will greatly enhance this App's ability to interact with services provided by your favorite calibre plugins. We highly recommend you look into it."),
                     primaryButton: .default(Text("Great, show me")) {
-                        dsreaderHelperInstructionPresenting = true
-                        helperStatus = nil
+                        viewModel.dsreaderHelperInstructionPresenting = true
+                        viewModel.helperStatus = nil
                     },
                     secondaryButton: .cancel(Text("Maybe Later")) {
-                        helperStatus = nil
+                        viewModel.helperStatus = nil
                     }
                 )
             }
             return Alert(
                 title: Text("Unexpected"),
                 dismissButton: .cancel(Text("Dismiss")) {
-                    helperStatus = nil
+                    viewModel.helperStatus = nil
                 }
             )
         }
-        .sheet(isPresented: $dsreaderHelperInstructionPresenting, content: {
+        .sheet(isPresented: $viewModel.dsreaderHelperInstructionPresenting, content: {
             instructions()
                 .padding()
         })
-    }
-    
-    private func setStates() {
-        let dsreaderHelperServer = modelData.queryServerDSReaderHelper(server: server) ?? {
-            var dsreaderHelper = CalibreServerDSReaderHelper(port: 0)
-            if let url = modelData.calibreServerService.getServerUrlByReachability(server: server) ?? URL(string: server.baseUrl) ?? URL(string: server.publicUrl) {
-                dsreaderHelper.port = (url.port ?? -1) + 1
-            }
-            return dsreaderHelper
-        }()
-        
-        configurationData = dsreaderHelperServer.configurationData
-        configuration = dsreaderHelperServer.configuration
-        
-        self.dsreaderHelperServer = dsreaderHelperServer
-        portStr = dsreaderHelperServer.port.description
-    }
-    
-    private func connect() {
-        refreshCancellable?.cancel()
-        configurationData = nil
-        configuration = nil
-        helperStatus = "Connecting..."
-
-        let connector = DSReaderHelperConnector(calibreServerService: modelData.calibreServerService, server: server, dsreaderHelperServer: dsreaderHelperServer, goodreadsSync: nil)
-        
-        Task {
-            do {
-                let (config, data) = try await connector.refreshConfiguration("_")
-                guard config.dsreader_helper_prefs != nil else {
-                    throw URLError(.badServerResponse)
-                }
-                configuration = config
-                configurationData = data
-                helperStatus = "Connected"
-
-                if configuration?.count_pages_prefs != nil {
-                    helperStatus = "Pulling Library-Specific Configurations..."
-                    var libraryConfigs:[String: CalibreCountPagesPrefs.LibraryConfig] = [:]
-                    
-                    try await withThrowingTaskGroup(of: (String, CalibreDSReaderHelperConfiguration).self) { group in
-                        for libraryKey in modelData.calibreLibraries.filter({ $0.value.server.uuid == server.uuid
-                            &&
-                            $0.value.hidden == false
-                        }).map ({ $0.value.key }) {
-                            group.addTask {
-                                return (libraryKey, try await connector.refreshConfiguration(libraryKey).0)
-                            }
-                        }
-                        
-                        for try await (libraryKey, config) in group {
-                            if let libraryConfig = config.count_pages_prefs?.library_config?[libraryKey] {
-                                libraryConfigs[libraryKey] = libraryConfig
-                            }
-                        }
-                    }
-                    configuration?.count_pages_prefs?.library_config = libraryConfigs
-                    configurationData = try JSONEncoder().encode(configuration!)
-                }
-                
-                configAlertItem = AlertItem(id: "updateConfigAlert")
-            } catch {
-                refreshCancellable = connector.refreshConfiguration()?
-                    .receive(on: DispatchQueue.main)
-                    .sink(receiveCompletion: { complete in
-                        print("receiveCompletion \(complete)")
-                        switch(complete) {
-                        case .finished:
-                            break
-                        default:
-                            helperStatus = "Failed to Connect"
-                            configAlertItem = AlertItem(id: "failedConnectConfigAlert")
-                        }
-                    }, receiveValue: { data in
-                        let decoder = JSONDecoder()
-                        var config: CalibreDSReaderHelperConfiguration? = nil
-                        do {
-                            config = try decoder.decode(CalibreDSReaderHelperConfiguration.self, from: data.data)
-                        } catch {
-                            print(error)
-                        }
-                        if let config = config, config.dsreader_helper_prefs != nil {
-                            configuration = config
-                            configurationData = data.data
-                            helperStatus = "Connected"
-
-                            configAlertItem = AlertItem(id: "updateConfigAlert")
-                        } else {
-                            helperStatus = "Failed"
-        //                    failedParseConfigAlertPresenting = true
-                            configAlertItem = AlertItem(id: "failedParseConfigAlert")
-                        }
-                    })
-            }
-        }
-    }
-    
-    private func update() {
-        guard let configuration = configuration else { return }
-        dsreaderHelperServer.configuration = configuration
-        dsreaderHelperServer.configurationData = configurationData
-        
-        modelData.updateServerDSReaderHelper(serverId: server.id, dsreaderHelper: dsreaderHelperServer, realm: modelData.realm)
-        
-        helperStatus = nil
     }
     
     @ViewBuilder
@@ -397,19 +265,17 @@ struct ServerOptionsDSReaderHelper: View {
             }
         }
     }
-    
 }
 
 struct ServerOptionsDSReaderHelper_Previews: PreviewProvider {
     static private var modelData = ModelData()
 
     @State static private var server = CalibreServer(uuid: .init(), name: "", baseUrl: "", hasPublicUrl: false, publicUrl: "", hasAuth: false, username: "", password: "")
-
-    @State static private var dsreaderHelperServer = CalibreServerDSReaderHelper(port: 1234)
     @State static private var updater = 0
     static var previews: some View {
+        let viewModel = ServerViewModel(modelData: modelData, server: server)
         NavigationView {
-            ServerOptionsDSReaderHelper(server: $server, dsreaderHelperServer: dsreaderHelperServer, updater: $updater)
+            ServerOptionsDSReaderHelper(viewModel: viewModel, server: $server, updater: $updater)
                 .environmentObject(modelData)
         }
         .navigationViewStyle(StackNavigationViewStyle())

--- a/YetAnotherEBookReader/Views/SettingsView/ServerView/ServerViewModel.swift
+++ b/YetAnotherEBookReader/Views/SettingsView/ServerView/ServerViewModel.swift
@@ -1,0 +1,439 @@
+//
+//  ServerViewModel.swift
+//  YetAnotherEBookReader
+//
+//  Created by Antigravity on 2026/6/12.
+//
+
+import Foundation
+import Combine
+import RealmSwift
+import SwiftUI
+
+@MainActor
+class ServerViewModel: ObservableObject {
+    let modelData: ModelData
+    private var serverId: String? // nil if adding a new server
+    
+    // Binding fields for server editing (AddModServerView)
+    @Published var calibreServerUUID: UUID
+    @Published var calibreServerName: String = ""
+    @Published var calibreServerUrl: String = ""
+    @Published var calibreServerUrlWelformed: String = ""
+    @Published var calibreServerUrlPublic: String = ""
+    @Published var calibreServerSetPublicAddress: Bool = false
+    @Published var calibreServerNeedAuth: Bool = false
+    @Published var calibreUsername: String = ""
+    @Published var calibrePassword: String = ""
+    @Published var calibrePasswordVisible: Bool = false
+    @Published var dataAction: String? = nil
+    @Published var isProbing: Bool = false
+    @Published var calibreServerInfo: CalibreServerInfo? = nil
+    @Published var serverCalibreInfoPresenting: Bool = false
+    @Published var alertItem: AlertItem? = nil
+    
+    // Server Detail properties (ServerDetailView)
+    @Published var libraryList: [String] = []
+    @Published var selectedLibrary: String? = nil
+    @Published var syncingLibrary: Bool = false
+    @Published var libraryRestoreListActive: Bool = false
+    @Published var libraryRestoreListSelection: Set<String> = []
+    
+    // DSReader Helper properties (ServerOptionsDSReaderHelper)
+    @Published var dsreaderHelperServer = CalibreServerDSReaderHelper(port: 0)
+    @Published var portStr: String = ""
+    @Published var configurationData: Data? = nil
+    @Published var configuration: CalibreDSReaderHelperConfiguration? = nil
+    @Published var helperStatus: String? = nil
+    @Published var configAlertItem: AlertItem? = nil
+    @Published var dsreaderHelperInstructionPresenting: Bool = false
+    
+    private var cancellables = Set<AnyCancellable>()
+    private var refreshCancellable: AnyCancellable?
+    
+    init(modelData: ModelData, server: CalibreServer?) {
+        self.modelData = modelData
+        
+        if let server = server {
+            self.serverId = server.id
+            self.calibreServerUUID = server.uuid
+            
+            // Populate basic fields
+            self.calibreServerName = server.name
+            self.calibreServerUrl = server.baseUrl
+            self.calibreServerUrlPublic = server.publicUrl
+            self.calibreServerSetPublicAddress = server.hasPublicUrl
+            self.calibreServerNeedAuth = server.hasAuth
+            self.calibreUsername = server.username
+            self.calibrePassword = server.password
+        } else {
+            self.serverId = nil
+            self.calibreServerUUID = UUID()
+        }
+        
+        setupBindings()
+    }
+    
+    func setupBindings() {
+        // Observe calibreLibraries to keep libraryList updated
+        modelData.$calibreLibraries
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard let self = self else { return }
+                self.updateLibraryList()
+            }
+            .store(in: &cancellables)
+            
+        // Map portStr changes back to dsreaderHelperServer.port
+        $portStr
+            .sink { [weak self] newValue in
+                guard let self = self else { return }
+                let filtered = newValue.filter { "0123456789".contains($0) }
+                if let num = Int(filtered), num != self.dsreaderHelperServer.port {
+                    if num > 65535 {
+                        self.dsreaderHelperServer.port = 65535
+                    } else if num < 1024 {
+                        self.dsreaderHelperServer.port = 1024
+                    } else {
+                        self.dsreaderHelperServer.port = num
+                    }
+                }
+            }
+            .store(in: &cancellables)
+    }
+    
+    // MARK: - Add / Modify Server Actions (AddModServerView)
+    
+    func resetStates(server: CalibreServer) {
+        self.calibreServerName = server.name
+        self.calibreServerUrl = server.baseUrl
+        self.calibreUsername = server.username
+        self.calibrePassword = server.password
+        self.calibreServerUrlPublic = server.publicUrl
+        self.calibreServerSetPublicAddress = server.hasPublicUrl
+        self.calibreServerNeedAuth = server.hasAuth
+        self.updateLibraryList()
+    }
+    
+    func processInputAction(server: CalibreServer, completion: @escaping () -> Void) {
+        if server.baseUrl.isEmpty {
+            dataAction = "Add"
+            processUrlInputs(server: server)
+            addServerConfirmButtonAction(completion: completion)
+        } else {
+            dataAction = "Mod"
+            processUrlInputs(server: server)
+            modServerConfirmButtonAction(completion: completion)
+        }
+        self.serverCalibreInfoPresenting = true
+    }
+    
+    private func processUrlInputs(server: CalibreServer) {
+        if calibreServerUrl != server.baseUrl {
+            if calibreServerUrl.contains("://") == false {
+                calibreServerUrl = "http://" + calibreServerUrl
+            }
+            if var components = URLComponents(string: calibreServerUrl) {
+                if components.scheme == nil {
+                    components.scheme = "http://"
+                }
+                if components.path == "" {
+                    components.path = "/"
+                }
+                if let s = components.string {
+                    calibreServerUrl = s
+                }
+            }
+        }
+        if calibreServerUrlPublic != server.publicUrl, var components = URLComponents(string: calibreServerUrlPublic) {
+            if components.scheme == nil {
+                components.scheme = "http://"
+            }
+            if components.path == "" {
+                components.path = "/"
+            }
+            if let s = components.string {
+                calibreServerUrlPublic = s
+            }
+        }
+    }
+    
+    private func addServerConfirmButtonAction(completion: @escaping () -> Void) {
+        if calibreServerName.isEmpty {
+            if let url = URL(string: calibreServerUrl), let host = url.host {
+                calibreServerName = host
+            } else {
+                calibreServerName = "Unnamed"
+            }
+        }
+        
+        if let existingServer = modelData.calibreServers.values.first(where: { server in
+            server.baseUrl == calibreServerUrl
+            && server.username == calibreUsername
+            && server.removed == false
+        }) {
+            alertItem = AlertItem(id: "Exist", msg: "Conflict with \"\(existingServer.name)\"\nA server with the same address and username already exists")
+            return
+        }
+
+        calibreServerUUID = .init()
+        let calibreServer = CalibreServer(
+            uuid: calibreServerUUID,
+            name: calibreServerName,
+            baseUrl: calibreServerUrl,
+            hasPublicUrl: calibreServerSetPublicAddress,
+            publicUrl: calibreServerUrlPublic,
+            hasAuth: calibreServerNeedAuth,
+            username: calibreUsername,
+            password: calibrePassword
+        )
+        
+        performProbeServer(server: calibreServer, isAdd: true, completion: completion)
+    }
+    
+    func addServerConfirmed(serverBinding: Binding<CalibreServer>, isActiveBinding: Binding<Bool>) {
+        guard let serverInfo = calibreServerInfo else { return }
+        
+        var newServer = serverInfo.server
+        newServer.defaultLibrary = serverInfo.defaultLibrary
+        
+        let libraries: [CalibreLibrary] = serverInfo.libraryMap
+            .sorted { $0.key < $1.key }
+            .map {
+                .init(
+                    server: serverInfo.server,
+                    key: $0,
+                    name: $1,
+                    autoUpdate: false,
+                    discoverable: true
+                )
+            }
+        
+        modelData.addServer(server: newServer, libraries: libraries)
+        if let url = URL(string: newServer.baseUrl) {
+            modelData.updateServerDSReaderHelper(
+                serverId: newServer.id,
+                dsreaderHelper: CalibreServerDSReaderHelper(
+                    port: (url.port ?? -1) + 1
+                ),
+                realm: modelData.realm)
+        }
+        
+        modelData.probeServersReachability(with: [newServer.id], updateLibrary: true, autoUpdateOnly: true)
+        
+        serverBinding.wrappedValue = newServer
+        isActiveBinding.wrappedValue = false
+    }
+    
+    private func modServerConfirmButtonAction(completion: @escaping () -> Void) {
+        guard let serverId = serverId, let server = modelData.calibreServers[serverId] else { return }
+        calibreServerUUID = server.uuid
+        let newServer = CalibreServer(
+            uuid: calibreServerUUID,
+            name: calibreServerName,
+            baseUrl: calibreServerUrl,
+            hasPublicUrl: calibreServerSetPublicAddress,
+            publicUrl: calibreServerUrlPublic,
+            hasAuth: calibreServerNeedAuth,
+            username: calibreUsername,
+            password: calibrePassword
+        )
+        
+        if let existingServer = modelData.calibreServers.values.first(where: { s in
+            s.uuid != newServer.uuid
+            && s.baseUrl == newServer.baseUrl
+            && s.username == newServer.username
+            && s.removed == false
+        }) {
+            alertItem = AlertItem(id: "Exist", msg: "Conflict with \"\(existingServer.name)\"\nA server with the same address and username already exists")
+            return
+        }
+        
+        performProbeServer(server: newServer, isAdd: false, completion: completion)
+    }
+    
+    func modServerConfirmed(serverBinding: Binding<CalibreServer>, isActiveBinding: Binding<Bool>) {
+        guard let serverInfo = calibreServerInfo else {
+            alertItem = AlertItem(id: "Error", msg: "Unexpected Error")
+            return
+        }
+        
+        var newServer = serverInfo.request.server
+        newServer.defaultLibrary = serverInfo.defaultLibrary
+        newServer.removed = serverBinding.wrappedValue.removed
+        
+        serverBinding.wrappedValue = newServer
+        isActiveBinding.wrappedValue = false
+    }
+    
+    private func performProbeServer(server: CalibreServer, isAdd: Bool, completion: @escaping () -> Void) {
+        isProbing = true
+        Task {
+            let serverInfo = await modelData.probeServer(request: .init(server: server, isPublic: false, updateLibrary: false, autoUpdateOnly: true, incremental: true))
+            
+            self.calibreServerInfo = serverInfo
+            if let serverInfo = serverInfo {
+                for (key, name) in serverInfo.libraryMap {
+                    await modelData.probeLibrary(request: .init(library: .init(server: serverInfo.request.server, key: key, name: name)))
+                }
+            }
+            self.isProbing = false
+            completion()
+        }
+    }
+    
+    func disableProbeServerCancellable() {
+        self.calibreServerInfo = nil
+        self.isProbing = false
+    }
+    
+    // MARK: - Server Details actions (ServerDetailView)
+    
+    func updateLibraryList() {
+        guard let serverId = serverId else { return }
+        libraryList = modelData.calibreLibraries.values.filter { library in
+            library.server.id == serverId && library.hidden == false
+        }
+        .sorted { $0.name < $1.name }
+        .map { $0.id }
+    }
+    
+    func deleteLibrary(at offsets: IndexSet) {
+        let deletedLibraryIds = offsets.map { libraryList[$0] }
+        deletedLibraryIds.forEach { libraryId in
+            self.modelData.hideLibrary(libraryId: libraryId)
+            
+            guard self.modelData.librarySyncStatus[libraryId]?.isSync != true else { return }
+            
+            guard let library = self.modelData.calibreLibraries[libraryId] else { return }
+            
+            self.modelData.calibreUpdatedSubject.send(.library(library))
+            
+            Task {
+                await self.modelData.removeLibrary(library: library)
+            }
+        }
+        updateLibraryList()
+    }
+    
+    func restoreSelectedLibraries(updater: Binding<Int>) {
+        libraryRestoreListSelection.forEach { libId in
+            modelData.restoreLibrary(libraryId: libId)
+            if let library = self.modelData.calibreLibraries[libId], library.discoverable {
+                self.modelData.calibreUpdatedSubject.send(.library(library))
+            }
+        }
+        updater.wrappedValue += 1
+        libraryRestoreListActive.toggle()
+    }
+    
+    func removeDeleteBooksFromServer(server: CalibreServer) {
+        modelData.removeDeleteBooksFromServer(server: server)
+    }
+    
+    func probeReachability(server: CalibreServer) {
+        modelData.probeServersReachability(with: [server.id], updateLibrary: true, autoUpdateOnly: true, incremental: false)
+    }
+    
+    // MARK: - DSReader Helper actions (ServerOptionsDSReaderHelper)
+    
+    func setDSReaderStates(server: CalibreServer) {
+        let dsHelper = modelData.queryServerDSReaderHelper(server: server) ?? {
+            var dsreaderHelper = CalibreServerDSReaderHelper(port: 0)
+            if let url = modelData.calibreServerService.getServerUrlByReachability(server: server) ?? URL(string: server.baseUrl) ?? URL(string: server.publicUrl) {
+                dsreaderHelper.port = (url.port ?? -1) + 1
+            }
+            return dsreaderHelper
+        }()
+        
+        configurationData = dsHelper.configurationData
+        configuration = dsHelper.configuration
+        self.dsreaderHelperServer = dsHelper
+        portStr = dsHelper.port.description
+    }
+    
+    func connectDSReader(server: CalibreServer) {
+        refreshCancellable?.cancel()
+        configurationData = nil
+        configuration = nil
+        helperStatus = "Connecting..."
+
+        let connector = DSReaderHelperConnector(calibreServerService: modelData.calibreServerService, server: server, dsreaderHelperServer: dsreaderHelperServer, goodreadsSync: nil)
+        
+        Task {
+            do {
+                let (config, data) = try await connector.refreshConfiguration("_")
+                guard config.dsreader_helper_prefs != nil else {
+                    throw URLError(.badServerResponse)
+                }
+                var updatedConfig = config
+                var updatedData = data
+                
+                if config.count_pages_prefs != nil {
+                    self.helperStatus = "Pulling Library-Specific Configurations..."
+                    var libraryConfigs: [String: CalibreCountPagesPrefs.LibraryConfig] = [:]
+                    
+                    try await withThrowingTaskGroup(of: (String, CalibreDSReaderHelperConfiguration).self) { group in
+                        let activeLibraries = modelData.calibreLibraries.filter {
+                            $0.value.server.uuid == server.uuid && !$0.value.hidden
+                        }.map { $0.value.key }
+                        
+                        for libraryKey in activeLibraries {
+                            group.addTask {
+                                return (libraryKey, try await connector.refreshConfiguration(libraryKey).0)
+                            }
+                        }
+                        
+                        for try await (libraryKey, libConfig) in group {
+                            if let libraryConfig = libConfig.count_pages_prefs?.library_config?[libraryKey] {
+                                libraryConfigs[libraryKey] = libraryConfig
+                            }
+                        }
+                    }
+                    updatedConfig.count_pages_prefs?.library_config = libraryConfigs
+                    updatedData = try JSONEncoder().encode(updatedConfig)
+                }
+                
+                self.configuration = updatedConfig
+                self.configurationData = updatedData
+                self.helperStatus = "Connected"
+                self.configAlertItem = AlertItem(id: "updateConfigAlert")
+            } catch {
+                // Fallback to Combine
+                refreshCancellable = connector.refreshConfiguration()?
+                    .receive(on: DispatchQueue.main)
+                    .sink(receiveCompletion: { [weak self] complete in
+                        guard let self = self else { return }
+                        switch complete {
+                        case .finished:
+                            break
+                        default:
+                            self.helperStatus = "Failed to Connect"
+                            self.configAlertItem = AlertItem(id: "failedConnectConfigAlert")
+                        }
+                    }, receiveValue: { [weak self] data in
+                        guard let self = self else { return }
+                        let decoder = JSONDecoder()
+                        if let config = try? decoder.decode(CalibreDSReaderHelperConfiguration.self, from: data.data), config.dsreader_helper_prefs != nil {
+                            self.configuration = config
+                            self.configurationData = data.data
+                            self.helperStatus = "Connected"
+                            self.configAlertItem = AlertItem(id: "updateConfigAlert")
+                        } else {
+                            self.helperStatus = "Failed"
+                            self.configAlertItem = AlertItem(id: "failedParseConfigAlert")
+                        }
+                    })
+            }
+        }
+    }
+    
+    func updateDSReaderHelperConfig(server: CalibreServer) {
+        guard let configuration = configuration else { return }
+        dsreaderHelperServer.configuration = configuration
+        dsreaderHelperServer.configurationData = configurationData
+        
+        modelData.updateServerDSReaderHelper(serverId: server.id, dsreaderHelper: dsreaderHelperServer, realm: modelData.realm)
+        helperStatus = nil
+    }
+}

--- a/YetAnotherEBookReader/Views/SettingsView/SettingsView.swift
+++ b/YetAnotherEBookReader/Views/SettingsView/SettingsView.swift
@@ -7,7 +7,6 @@
 
 import SwiftUI
 import Combine
-import RealmSwift
 
 struct SettingsView: View {
     @EnvironmentObject var modelData: ModelData
@@ -266,7 +265,7 @@ struct SettingsView: View {
         print("\(#function) addServer finished")
         
         DispatchQueue(label: "data").async {
-            let realm = try! Realm(configuration: modelData.realmConf)
+//            let realm = try! Realm(configuration: modelData.realmConf)
 
             //update books
 //            let booksCached = realm.objects(CalibreBookRealm.self)

--- a/YetAnotherEBookReader/Views/SettingsView/SettingsView.swift
+++ b/YetAnotherEBookReader/Views/SettingsView/SettingsView.swift
@@ -40,6 +40,7 @@ struct SettingsView: View {
             }) {
                 NavigationLink(
                     destination: AddModServerView(
+                        viewModel: ServerViewModel(modelData: modelData, server: nil),
                         server: Binding<CalibreServer>(
                             get: {
                                 .init(uuid: .init(), name: "", baseUrl: "", hasPublicUrl: false, publicUrl: "", hasAuth: false, username: "", password: "")

--- a/YetAnotherEBookReader/Views/ShelfView/RecentShelfController.swift
+++ b/YetAnotherEBookReader/Views/ShelfView/RecentShelfController.swift
@@ -300,13 +300,11 @@ class RecentShelfController: UIViewController, PlainShelfViewDelegate {
         if book.library.server.isLocal {
             //same as options
             onBookOptionsClicked(shelfView, index: index, bookId: bookId, bookTitle: bookTitle, frame: inShelfView)
-        } else if let bookRealm = modelData.getBookRealm(forPrimaryKey: bookId),
-                  let bookAnnoRealm = book.readPos.realm {
+        } else if let _ = modelData.getBookRealm(forPrimaryKey: bookId) {
             
-            let bookDetailView = BookDetailView(book: bookRealm, viewMode: .SHELF)
+            let bookDetailView = BookDetailView(bookId: bookId, viewMode: .SHELF)
                 .environmentObject(modelData)
                 .environmentObject(modelData.downloadManager)
-                .environment(\.realmConfiguration, bookAnnoRealm.configuration)
             
             let detailView = UIHostingController(
                 rootView: bookDetailView

--- a/YetAnotherEBookReader/Views/ShelfView/SectionShelfController.swift
+++ b/YetAnotherEBookReader/Views/ShelfView/SectionShelfController.swift
@@ -504,12 +504,12 @@ class SectionShelfController: UIViewController, SectionShelfCompositionalViewDel
 //        becomeFirstResponder()
 //        UIMenuController.shared.showMenu(from: shelfView, rect: inShelfView)
         
-        guard let bookRealm = modelData.getBookRealm(forPrimaryKey: bookId)
+        guard let _ = modelData.getBookRealm(forPrimaryKey: bookId)
         else {
             return
         }
         
-        let bookDetailView = BookDetailView(book: bookRealm, viewMode: .SHELF)
+        let bookDetailView = BookDetailView(bookId: bookId, viewMode: .SHELF)
             .environmentObject(modelData)
             .environmentObject(modelData.downloadManager)
         let detailView = UIHostingController(
@@ -536,12 +536,12 @@ class SectionShelfController: UIViewController, SectionShelfCompositionalViewDel
 //        becomeFirstResponder()
 //        UIMenuController.shared.showMenu(from: shelfView, rect: inShelfView)
         
-        guard let bookRealm = modelData.getBookRealm(forPrimaryKey: bookId)
+        guard let _ = modelData.getBookRealm(forPrimaryKey: bookId)
         else {
             return
         }
         
-        let bookDetailView = BookDetailView(book: bookRealm, viewMode: .SHELF)
+        let bookDetailView = BookDetailView(bookId: bookId, viewMode: .SHELF)
             .environmentObject(modelData)
             .environmentObject(modelData.downloadManager)
         let detailView = UIHostingController(

--- a/YetAnotherEBookReaderTests/BookDetailViewModelTests.swift
+++ b/YetAnotherEBookReaderTests/BookDetailViewModelTests.swift
@@ -13,17 +13,26 @@ class BookDetailViewModelTests: XCTestCase {
         mockModelData = ModelData(mock: true)
         viewModel = BookDetailViewModel(modelData: mockModelData)
         
+        guard let library = mockModelData.calibreLibraries.first?.value else {
+            XCTFail("No mock library found in mockModelData")
+            return
+        }
+        
         mockBookRealm = CalibreBookRealm()
-        mockBookRealm.serverUUID = "mock-uuid"
-        mockBookRealm.libraryName = "Mock Library"
+        mockBookRealm.serverUUID = library.server.uuid.uuidString
+        mockBookRealm.libraryName = library.name
         mockBookRealm.idInLib = 123
         mockBookRealm.title = "Test Book"
+        mockBookRealm.updatePrimaryKey()
         
-        let library = CalibreLibrary(server: CalibreServer(uuid: UUID(), name: "MockServer", baseUrl: "http://localhost", hasPublicUrl: false, publicUrl: "", hasAuth: false, username: "", password: ""), key: "lib1", name: "Mock Library")
         mockCalibreBook = CalibreBook(id: 123, library: library)
         mockCalibreBook.title = "Test Book"
         
-        viewModel.setup(book: mockBookRealm, calibreBook: mockCalibreBook)
+        try! mockModelData.realm.write {
+            mockModelData.realm.add(mockBookRealm, update: .modified)
+        }
+        
+        viewModel.setup(bookId: mockBookRealm.primaryKey!)
     }
 
     override func tearDownWithError() throws {
@@ -97,7 +106,14 @@ class BookDetailViewModelTests: XCTestCase {
     }
 
     func testConvertBookRealm() throws {
-        let result = viewModel.convert(bookRealm: mockBookRealm)
+        let nonQueryableBook = CalibreBookRealm()
+        nonQueryableBook.serverUUID = "non-existent-uuid"
+        nonQueryableBook.libraryName = "Non Existent Library"
+        nonQueryableBook.idInLib = 999
+        nonQueryableBook.title = "Non Queryable Book"
+        nonQueryableBook.updatePrimaryKey()
+        
+        let result = viewModel.convert(bookRealm: nonQueryableBook)
         XCTAssertNil(result, "Should return nil if library is not queryable in mock model data")
     }
 

--- a/YetAnotherEBookReaderTests/ReaderOptionsViewModelTests.swift
+++ b/YetAnotherEBookReaderTests/ReaderOptionsViewModelTests.swift
@@ -1,0 +1,70 @@
+//
+//  ReaderOptionsViewModelTests.swift
+//  YetAnotherEBookReaderTests
+//
+//  Created by Antigravity on 2026/6/13.
+//
+
+import XCTest
+import SwiftUI
+import Combine
+@testable import YetAnotherEBookReader
+
+class ReaderOptionsViewModelTests: XCTestCase {
+    var viewModel: ReaderOptionsViewModel!
+    var mockModelData: ModelData!
+    var cancellables: Set<AnyCancellable>!
+    
+    override func setUpWithError() throws {
+        mockModelData = ModelData(mock: true)
+        viewModel = ReaderOptionsViewModel(modelData: mockModelData, fontsManager: mockModelData.fontsManager)
+        cancellables = []
+    }
+    
+    override func tearDownWithError() throws {
+        viewModel = nil
+        mockModelData = nil
+        cancellables = nil
+    }
+    
+    func testInitialization() throws {
+        XCTAssertFalse(viewModel.optionsHelpFormat)
+        XCTAssertFalse(viewModel.optionsHelpReader)
+        XCTAssertFalse(viewModel.optionsHelpFont)
+        XCTAssertFalse(viewModel.fontsFolderPresenting)
+        XCTAssertFalse(viewModel.fontsDetailPresenting)
+    }
+    
+    func testPopoverToggles() throws {
+        viewModel.startImport()
+        XCTAssertTrue(viewModel.fontsFolderPresenting)
+        
+        viewModel.startViewDetails()
+        XCTAssertTrue(viewModel.fontsDetailPresenting)
+    }
+    
+    func testDismissAllBindings() throws {
+        viewModel.optionsHelpFormat = true
+        viewModel.fontsDetailPresenting = true
+        
+        let expectation = XCTestExpectation(description: "Wait for dismiss publisher")
+        
+        // Trigger dismiss
+        mockModelData.dismissAllSubject.send("")
+        
+        DispatchQueue.main.async {
+            XCTAssertFalse(self.viewModel.optionsHelpFormat)
+            XCTAssertFalse(self.viewModel.fontsDetailPresenting)
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 1.0)
+    }
+    
+    func testPreferredFormatBinding() throws {
+        let binding = viewModel.preferredFormatBinding
+        binding.wrappedValue = .EPUB
+        XCTAssertEqual(binding.wrappedValue, .EPUB)
+        XCTAssertEqual(mockModelData.getPreferredFormat(), .EPUB)
+    }
+}

--- a/YetAnotherEBookReaderTests/UnifiedCategoryServiceTests.swift
+++ b/YetAnotherEBookReaderTests/UnifiedCategoryServiceTests.swift
@@ -1,0 +1,346 @@
+//
+//  UnifiedCategoryServiceTests.swift
+//  YetAnotherEBookReaderTests
+//
+//  Created by Antigravity on 2026-06-12.
+//
+
+import XCTest
+import Combine
+import RealmSwift
+@testable import YetAnotherEBookReader
+
+@MainActor
+class UnifiedCategoryServiceTests: XCTestCase {
+    
+    var repository: MockCategoryCacheRepository!
+    var libraryProvider: MockLibraryProvider!
+    var serverService: CalibreServerService!
+    var libraryCategoryService: LibraryCategoryService!
+    var unifiedCategoryService: UnifiedCategoryService!
+    var mergeService: UnifiedCategoryMergeService!
+    
+    var mockLibrary1: CalibreLibrary!
+    var mockLibrary2: CalibreLibrary!
+    
+    override func setUp() async throws {
+        try await super.setUp()
+        
+        let config = Realm.Configuration(inMemoryIdentifier: "UnifiedCategoryServiceTests-\(UUID().uuidString)")
+        DatabaseService.shared.setup(conf: config)
+        let modelData = ModelData(mock: true)
+        modelData.realmConf = config
+        
+        let server1 = CalibreServer(uuid: UUID(), name: "Server1", baseUrl: "http://localhost/1", hasPublicUrl: false, publicUrl: "", hasAuth: false, username: "", password: "")
+        mockLibrary1 = CalibreLibrary(server: server1, key: "lib1", name: "Library 1")
+        
+        let server2 = CalibreServer(uuid: UUID(), name: "Server2", baseUrl: "http://localhost/2", hasPublicUrl: false, publicUrl: "", hasAuth: false, username: "", password: "")
+        mockLibrary2 = CalibreLibrary(server: server2, key: "lib2", name: "Library 2")
+        
+        repository = MockCategoryCacheRepository()
+        libraryProvider = MockLibraryProvider()
+        libraryProvider.libraries = [
+            mockLibrary1.id: mockLibrary1,
+            mockLibrary2.id: mockLibrary2
+        ]
+        
+        // Setup reachability staging in modelData
+        let probeRequest1 = CalibreProbeServerRequest(server: server1, isPublic: false, updateLibrary: false, autoUpdateOnly: false, incremental: false)
+        let info1 = CalibreServerInfo(server: server1, isPublic: false, url: URL(string: "http://localhost/1")!, reachable: true, probing: false, errorMsg: "Success", defaultLibrary: mockLibrary1.id, libraryMap: [mockLibrary1.id: "Library 1"], request: probeRequest1)
+        
+        let probeRequest2 = CalibreProbeServerRequest(server: server2, isPublic: false, updateLibrary: false, autoUpdateOnly: false, incremental: false)
+        let info2 = CalibreServerInfo(server: server2, isPublic: false, url: URL(string: "http://localhost/2")!, reachable: true, probing: false, errorMsg: "Success", defaultLibrary: mockLibrary2.id, libraryMap: [mockLibrary2.id: "Library 2"], request: probeRequest2)
+        
+        modelData.calibreServerInfoStaging = [
+            server1.uuid.uuidString: info1,
+            server2.uuid.uuidString: info2
+        ]
+        
+        serverService = modelData.calibreServerService
+        mergeService = UnifiedCategoryMergeService()
+        
+        libraryCategoryService = LibraryCategoryService(service: serverService, repository: repository)
+        unifiedCategoryService = UnifiedCategoryService(mergeService: mergeService, repository: repository, libraryProvider: libraryProvider)
+        
+        // Setup ephemeral URLSession with MockURLProtocol
+        let sessionConfig = URLSessionConfiguration.ephemeral
+        sessionConfig.protocolClasses = [MockURLProtocol.self]
+        let mockSession = URLSession(configuration: sessionConfig)
+        
+        // Register mock sessions in the service
+        for server in [server1, server2] {
+            for qos in [DispatchQoS.QoSClass.default, .background, .utility, .userInitiated, .userInteractive, .unspecified] {
+                let key = CalibreServerURLSessionKey(server: server, timeout: 600, qos: qos)
+                serverService.metadataSessions[key] = mockSession
+            }
+        }
+    }
+    
+    override func tearDown() async throws {
+        repository = nil
+        libraryProvider = nil
+        serverService = nil
+        libraryCategoryService = nil
+        unifiedCategoryService = nil
+        mergeService = nil
+        mockLibrary1 = nil
+        mockLibrary2 = nil
+        try await super.tearDown()
+    }
+    
+    // MARK: - Merge Service Tests
+    
+    func testMergeEmptyResults() {
+        let results: [LibraryCategoryResult] = []
+        let merged = mergeService.merge(categoryName: "Authors", searchString: "", results: results)
+        
+        XCTAssertEqual(merged.categoryName, "Authors")
+        XCTAssertEqual(merged.search, "")
+        XCTAssertEqual(merged.itemsCount, 0)
+        XCTAssertEqual(merged.totalNumber, 0)
+        XCTAssertTrue(merged.items.isEmpty)
+    }
+    
+    func testMergeAndAggregateMultipleLibraries() {
+        let item1 = LibraryCategoryItem(name: "Author A", averageRating: 4.0, count: 5, url: "urlA1")
+        let item2 = LibraryCategoryItem(name: "Author B", averageRating: 5.0, count: 2, url: "urlB1")
+        let result1 = LibraryCategoryResult(libraryId: "lib1", categoryName: "Authors", items: [item1, item2], generation: Date(), totalNumber: 2)
+        
+        let item3 = LibraryCategoryItem(name: "Author A", averageRating: 2.0, count: 5, url: "urlA2")
+        let item4 = LibraryCategoryItem(name: "Author C", averageRating: 3.0, count: 3, url: "urlC2")
+        let result2 = LibraryCategoryResult(libraryId: "lib2", categoryName: "Authors", items: [item3, item4], generation: Date(), totalNumber: 2)
+        
+        let merged = mergeService.merge(categoryName: "Authors", searchString: "", results: [result1, result2])
+        
+        XCTAssertEqual(merged.itemsCount, 3)
+        // Total books: 5 (Author A lib1) + 2 (Author B lib1) + 5 (Author A lib2) + 3 (Author C lib2) = 15
+        XCTAssertEqual(merged.totalNumber, 15)
+        
+        // Items must be sorted alphabetically: Author A, Author B, Author C
+        XCTAssertEqual(merged.items[0].name, "Author A")
+        XCTAssertEqual(merged.items[1].name, "Author B")
+        XCTAssertEqual(merged.items[2].name, "Author C")
+        
+        // Author A count: 5 + 5 = 10. Rating: (4.0*5 + 2.0*5)/10 = 3.0
+        XCTAssertEqual(merged.items[0].count, 10)
+        XCTAssertEqual(merged.items[0].averageRating, 3.0)
+        XCTAssertEqual(merged.items[0].libraryItems.count, 2)
+        XCTAssertEqual(merged.items[0].libraryItems["lib1"]?.url, "urlA1")
+        XCTAssertEqual(merged.items[0].libraryItems["lib2"]?.url, "urlA2")
+        
+        // Author B count: 2. Rating: 5.0
+        XCTAssertEqual(merged.items[1].count, 2)
+        XCTAssertEqual(merged.items[1].averageRating, 5.0)
+        
+        // Author C count: 3. Rating: 3.0
+        XCTAssertEqual(merged.items[2].count, 3)
+        XCTAssertEqual(merged.items[2].averageRating, 3.0)
+    }
+    
+    func testMergeWithFilter() {
+        let item1 = LibraryCategoryItem(name: "Stephen King", averageRating: 4.5, count: 10, url: "sk")
+        let item2 = LibraryCategoryItem(name: "J.K. Rowling", averageRating: 4.8, count: 7, url: "jkr")
+        let result = LibraryCategoryResult(libraryId: "lib1", categoryName: "Authors", items: [item1, item2], generation: Date(), totalNumber: 2)
+        
+        let merged = mergeService.merge(categoryName: "Authors", searchString: "rowling", results: [result])
+        
+        XCTAssertEqual(merged.itemsCount, 1)
+        XCTAssertEqual(merged.items[0].name, "J.K. Rowling")
+    }
+    
+    // MARK: - Fetch and Cache Concurrency Tests
+    
+    func testFetchAndCacheCategorySuccess() async throws {
+        let category = CalibreLibraryCategory(name: "Authors", url: "http://localhost/1/ajax/category/Authors", icon: "user", is_category: true)
+        
+        MockURLProtocol.requestHandler = { request in
+            guard let url = request.url else { throw URLError(.badURL) }
+            
+            let response = HTTPURLResponse(
+                url: url,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            
+            let responseJSON = """
+            {
+                "category_name": "Authors",
+                "base_url": "/ajax/category/Authors",
+                "total_num": 2,
+                "offset": 0,
+                "num": 2,
+                "sort": "name",
+                "sort_order": "asc",
+                "items": [
+                    {
+                        "name": "Author X",
+                        "average_rating": 4.5,
+                        "count": 3,
+                        "url": "urlX",
+                        "has_children": false
+                    },
+                    {
+                        "name": "Author Y",
+                        "average_rating": 3.8,
+                        "count": 1,
+                        "url": "urlY",
+                        "has_children": false
+                    }
+                ]
+            }
+            """
+            return (response, responseJSON.data(using: .utf8)!)
+        }
+        
+        let result = try await libraryCategoryService.fetchAndCacheCategory(library: mockLibrary1, category: category)
+        
+        XCTAssertEqual(result.libraryId, mockLibrary1.id)
+        XCTAssertEqual(result.categoryName, "Authors")
+        XCTAssertEqual(result.totalNumber, 2)
+        XCTAssertEqual(result.items.count, 2)
+        XCTAssertEqual(result.items[0].name, "Author X")
+        XCTAssertEqual(result.items[1].name, "Author Y")
+        
+        // Check repository cache
+        let cached = try repository.fetchLibraryCategoryResult(libraryId: mockLibrary1.id, categoryName: "Authors")
+        XCTAssertNotNil(cached)
+        XCTAssertEqual(cached?.totalNumber, 2)
+    }
+    
+    func testFetchAndCacheCategoryPagination() async throws {
+        let category = CalibreLibraryCategory(name: "Authors", url: "http://localhost/1/ajax/category/Authors", icon: "user", is_category: true)
+        
+        var requestCount = 0
+        MockURLProtocol.requestHandler = { request in
+            guard let url = request.url,
+                  let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems,
+                  let offsetStr = queryItems.first(where: { $0.name == "offset" })?.value,
+                  let offset = Int(offsetStr) else {
+                throw URLError(.badURL)
+            }
+            
+            requestCount += 1
+            
+            let response = HTTPURLResponse(
+                url: url,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            
+            let responseJSON: String
+            if offset == 0 {
+                responseJSON = """
+                {
+                    "category_name": "Authors",
+                    "base_url": "/ajax/category/Authors",
+                    "total_num": 3,
+                    "offset": 0,
+                    "num": 2,
+                    "sort": "name",
+                    "sort_order": "asc",
+                    "items": [
+                        { "name": "Author 1", "average_rating": 4.0, "count": 1, "url": "url1", "has_children": false },
+                        { "name": "Author 2", "average_rating": 4.1, "count": 2, "url": "url2", "has_children": false }
+                    ]
+                }
+                """
+            } else {
+                responseJSON = """
+                {
+                    "category_name": "Authors",
+                    "base_url": "/ajax/category/Authors",
+                    "total_num": 3,
+                    "offset": 2,
+                    "num": 1,
+                    "sort": "name",
+                    "sort_order": "asc",
+                    "items": [
+                        { "name": "Author 3", "average_rating": 4.2, "count": 3, "url": "url3", "has_children": false }
+                    ]
+                }
+                """
+            }
+            
+            return (response, responseJSON.data(using: .utf8)!)
+        }
+        
+        let result = try await libraryCategoryService.fetchAndCacheCategory(library: mockLibrary1, category: category)
+        
+        XCTAssertEqual(requestCount, 2)
+        XCTAssertEqual(result.items.count, 3)
+        XCTAssertEqual(result.totalNumber, 3)
+        XCTAssertEqual(result.items[0].name, "Author 1")
+        XCTAssertEqual(result.items[1].name, "Author 2")
+        XCTAssertEqual(result.items[2].name, "Author 3")
+    }
+    
+    // MARK: - Unified Category Service Tests
+    
+    func testUnifiedCategoryServiceMerge() async throws {
+        // Seed cache directly using correct library IDs
+        let item1 = LibraryCategoryItem(name: "Tag A", averageRating: 0.0, count: 5, url: "tagA")
+        let result1 = LibraryCategoryResult(libraryId: mockLibrary1.id, categoryName: "Tags", items: [item1], generation: Date(), totalNumber: 1)
+        try repository.saveLibraryCategoryResult(libraryId: mockLibrary1.id, categoryName: "Tags", result: result1)
+        
+        let item2 = LibraryCategoryItem(name: "Tag A", averageRating: 0.0, count: 10, url: "tagA")
+        let item3 = LibraryCategoryItem(name: "Tag B", averageRating: 0.0, count: 2, url: "tagB")
+        let result2 = LibraryCategoryResult(libraryId: mockLibrary2.id, categoryName: "Tags", items: [item2, item3], generation: Date(), totalNumber: 2)
+        try repository.saveLibraryCategoryResult(libraryId: mockLibrary2.id, categoryName: "Tags", result: result2)
+        
+        let merged = await unifiedCategoryService.mergeCategory(categoryName: "Tags", searchString: "")
+        
+        XCTAssertEqual(merged.itemsCount, 2)
+        XCTAssertEqual(merged.items[0].name, "Tag A")
+        XCTAssertEqual(merged.items[0].count, 15)
+        XCTAssertEqual(merged.items[1].name, "Tag B")
+        XCTAssertEqual(merged.items[1].count, 2)
+    }
+}
+
+// MARK: - Mocking Classes
+
+class MockCategoryCacheRepository: CategoryCacheRepository {
+    var cache: [String: LibraryCategoryResult] = [:]
+    
+    func fetchLibraryCategoryResult(libraryId: String, categoryName: String) throws -> LibraryCategoryResult? {
+        return cache["\(libraryId)-\(categoryName)"]
+    }
+    
+    func saveLibraryCategoryResult(libraryId: String, categoryName: String, result: LibraryCategoryResult) throws {
+        cache["\(libraryId)-\(categoryName)"] = result
+    }
+    
+    func fetchCategorySummaries() throws -> [CategoryCacheSummary] {
+        var summariesByName: [String: (itemsCount: Int, totalNumber: Int)] = [:]
+        for result in cache.values {
+            let name = result.categoryName
+            let current = summariesByName[name] ?? (0, 0)
+            summariesByName[name] = (
+                current.itemsCount + result.items.count,
+                current.totalNumber + result.totalNumber
+            )
+        }
+        return summariesByName.map { name, stats in
+            CategoryCacheSummary(
+                categoryName: name,
+                itemsCount: stats.itemsCount,
+                totalNumber: stats.totalNumber
+            )
+        }.sorted { $0.categoryName < $1.categoryName }
+    }
+    
+    func invalidateCategoryCache(libraryId: String, categoryName: String) throws {
+        if let result = cache["\(libraryId)-\(categoryName)"] {
+            let staleResult = LibraryCategoryResult(
+                libraryId: result.libraryId,
+                categoryName: result.categoryName,
+                items: result.items,
+                generation: Date(timeIntervalSince1970: 0),
+                totalNumber: result.totalNumber
+            )
+            cache["\(libraryId)-\(categoryName)"] = staleResult
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Separate category aggregation and caching logic behind protocol-based services
- Move Realm-specific search cache handling into a dedicated repository layer
- Update library, book detail, settings, and shelf flows to consume the new category and model APIs
- Refresh tests around category merging, book detail behavior, and reader options

## Testing
- Added and updated unit coverage for unified category service behavior and related view models
- Verified project integration compiles with the refactored service and repository wiring
- Not run (not requested)