### PR TITLE
Fix discover shelf filtering for cross-library author sections

### DIFF
--- a/YetAnotherEBookReader/Models/ShelfDataManager.swift
+++ b/YetAnotherEBookReader/Models/ShelfDataManager.swift
@@ -246,17 +246,18 @@ class YabrShelfDataModel: ObservableObject {
     
     func buildShelfSectionItem(category: CategoryObject) -> ShelfSectionItem {
         let sectionName = "\(category.type.rawValue): \(category.category)"
-        
+
         let books: [ShelfBookItem] = category.unifiedSearchResult?.books.map {
             ShelfBookItem(
                 id: $0.id.description,
                 title: $0.title,
                 coverURL: $0.coverURL?.absoluteString ?? "",
                 progress: 0,
-                status: .ready
+                status: .ready,
+                libraryId: $0.library.id
             )
         } ?? []
-        
+
         return ShelfSectionItem(id: sectionName, title: sectionName, books: books)
     }
     
@@ -378,14 +379,5 @@ extension AppContainerProtocol where Self: ObservableObject {
             progress: Int(floor(readerInfo.position.lastProgress)),
             status: status
         )
-    }
-}
-
-extension AppContainerProtocol where Self: ObservableObject {
-    static func parseShelfSectionId(sectionId: String) -> String? {
-        guard let sepRange = sectionId.range(of: " || ")
-        else { return nil }
-        let libraryId = String(sectionId[sectionId.startIndex..<sepRange.lowerBound])
-        return libraryId
     }
 }

--- a/YetAnotherEBookReader/Models/ShelfDataManager.swift
+++ b/YetAnotherEBookReader/Models/ShelfDataManager.swift
@@ -249,7 +249,7 @@ class YabrShelfDataModel: ObservableObject {
 
         let books: [ShelfBookItem] = category.unifiedSearchResult?.books.map {
             ShelfBookItem(
-                id: $0.id.description,
+                id: $0.inShelfId,
                 title: $0.title,
                 coverURL: $0.coverURL?.absoluteString ?? "",
                 progress: 0,

--- a/YetAnotherEBookReader/Views/ShelfView/SectionShelfView.swift
+++ b/YetAnotherEBookReader/Views/ShelfView/SectionShelfView.swift
@@ -209,5 +209,8 @@ struct SectionShelfView: View {
             }
         }
         .navigationViewStyle(StackNavigationViewStyle())
+        .onAppear {
+            viewModel.bootstrapIfDatabaseReady()
+        }
     }
 }

--- a/YetAnotherEBookReader/Views/ShelfView/SectionShelfViewModel.swift
+++ b/YetAnotherEBookReader/Views/ShelfView/SectionShelfViewModel.swift
@@ -37,20 +37,25 @@ final class SectionShelfViewModel: ObservableObject {
     init(container: AppContainer) {
         self.container = container
         setupSubscriptions()
-        bootstrapShelfDataModelIfNeeded()
+        bootstrapIfDatabaseReady()
     }
-    
-    private func bootstrapShelfDataModelIfNeeded() {
+
+    /// Idempotent bootstrap of the lazy `shelfDataModel`. Safe to call from
+    /// `init`, from the `calibreUpdatedSubject` sink, and from the view's
+    /// `.onAppear` to cover the case where the user first lands directly
+    /// on the Discover tab and the database-ready signal has not yet
+    /// been routed through the subject pipeline.
+    func bootstrapIfDatabaseReady() {
         guard container.logger != nil else { return }
-        
-        // Force lazy initialization of shelfDataModel and seed initial items if any
+        guard allDisplaySections.isEmpty else { return }
+
         let initialItems = container.shelfDataModel.discoverShelfItems.values.sorted(by: { $0.title < $1.title })
         if !initialItems.isEmpty {
             self.allDisplaySections = initialItems
             self.applyFiltering()
         }
     }
-    
+
     private func setupSubscriptions() {
         container.discoverShelfItemsSubject
             .sink { [weak self] sections in
@@ -59,17 +64,15 @@ final class SectionShelfViewModel: ObservableObject {
                 self.applyFiltering()
             }
             .store(in: &cancellables)
-            
+
         container.calibreUpdatedSubject
             .receive(on: DispatchQueue.main)
             .sink { [weak self] signal in
                 guard let self = self else { return }
-                
+
                 // If database just finished initializing, bootstrap shelfDataModel
-                if self.container.logger != nil && self.allDisplaySections.isEmpty {
-                    self.bootstrapShelfDataModelIfNeeded()
-                }
-                
+                self.bootstrapIfDatabaseReady()
+
                 if case .deleted(let deletedId) = signal {
                     if self.presentingBookDetailId == deletedId {
                         self.presentingBookDetailId = nil
@@ -147,19 +150,22 @@ final class SectionShelfViewModel: ObservableObject {
     }
     
     private func applyFiltering() {
+        // Aggregate the set of libraries actually present in the section
+        // book items. Sections are cross-library by category (e.g. "Author: A"),
+        // so the libraryId lives on each ShelfBookItem, not on the section id.
         let availableLibraryIds = Set(
-            allDisplaySections.compactMap { AppContainer.parseShelfSectionId(sectionId: $0.id) }
+            allDisplaySections.flatMap { $0.books.compactMap { $0.libraryId } }
         )
-        pickedLibraries.formIntersection(availableLibraryIds)
-        
-        let librarySet = Set<CalibreLibrary>(
-            allDisplaySections.compactMap { section -> CalibreLibrary? in
-                guard let libraryId = AppContainer.parseShelfSectionId(sectionId: section.id) else { return nil }
-                return container.libraryManager.calibreLibraries[libraryId]
-            }
-        )
-        let libraryList = librarySet.sorted(by: { $0.name < $1.name })
-        
+        // Prune picked libraries that no longer exist in the calibre library
+        // dictionary, but keep picked libraries that simply have no books in
+        // the current section set — those should still hide every section.
+        pickedLibraries.formIntersection(Set(container.libraryManager.calibreLibraries.keys))
+
+        let libraryList = container.libraryManager.calibreLibraries
+            .values
+            .filter { availableLibraryIds.contains($0.id) }
+            .sorted(by: { $0.name < $1.name })
+
         libraryFilters = libraryList.map { library in
             ShelfLibraryFilterItem(
                 id: library.id,
@@ -168,10 +174,19 @@ final class SectionShelfViewModel: ObservableObject {
                 isSelected: pickedLibraries.contains(library.id)
             )
         }
-        
-        displaySections = allDisplaySections.filter { section in
-            guard let libraryId = AppContainer.parseShelfSectionId(sectionId: section.id) else { return false }
-            return pickedLibraries.isEmpty || pickedLibraries.contains(libraryId)
+
+        if pickedLibraries.isEmpty {
+            displaySections = allDisplaySections
+            return
+        }
+
+        displaySections = allDisplaySections.compactMap { section in
+            let filteredBooks = section.books.filter { book in
+                guard let bookLibraryId = book.libraryId else { return false }
+                return pickedLibraries.contains(bookLibraryId)
+            }
+            guard !filteredBooks.isEmpty else { return nil }
+            return ShelfSectionItem(id: section.id, title: section.title, books: filteredBooks)
         }
     }
 }

--- a/YetAnotherEBookReader/Views/ShelfView/ShelfDisplayModels.swift
+++ b/YetAnotherEBookReader/Views/ShelfView/ShelfDisplayModels.swift
@@ -22,13 +22,15 @@ public struct ShelfBookItem: Identifiable, Equatable {
     public let coverURL: String
     public let progress: Int
     public let status: ShelfBookStatus
-    
-    public init(id: String, title: String, coverURL: String, progress: Int, status: ShelfBookStatus) {
+    public let libraryId: String?
+
+    public init(id: String, title: String, coverURL: String, progress: Int, status: ShelfBookStatus, libraryId: String? = nil) {
         self.id = id
         self.title = title
         self.coverURL = coverURL
         self.progress = progress
         self.status = status
+        self.libraryId = libraryId
     }
 }
 

--- a/YetAnotherEBookReaderTests/SectionShelfViewModelTests.swift
+++ b/YetAnotherEBookReaderTests/SectionShelfViewModelTests.swift
@@ -51,20 +51,11 @@ class SectionShelfViewModelTests: XCTestCase {
         mockAppContainer.calibreLibraries[library.id] = library
 
         let section = ShelfSectionItem(
-            id: "\(library.id) || testSection",
-            title: "Test Section",
+            id: "Author: testSection",
+            title: "Author: testSection",
             books: []
         )
 
-        // The viewModel buffers section updates through
-        // .collect(.byTime(RunLoop.main, .seconds(1))) before
-        // applying them, and the downstream
-        // .receive(on: DispatchQueue.main) re-dispatches the
-        // collected values to the main queue. async `await` on the
-        // MainActor pumps neither, so we run the main RunLoop in
-        // short bursts. The tight loop interleaves RunLoop iteration
-        // (which fires the collect's 1s timer) with main-queue
-        // drain (which lets the sink update displaySections).
         // The viewModel sink is wired directly to
         // discoverShelfItemsSubject (no .collect/.receive(on:)),
         // so it fires synchronously on send(). The shelf data
@@ -75,7 +66,7 @@ class SectionShelfViewModelTests: XCTestCase {
         mockAppContainer.discoverShelfItemsSubject.send([section])
 
         XCTAssertEqual(viewModel.displaySections.count, 1)
-        XCTAssertEqual(viewModel.displaySections.getOrNil(0)?.id, "\(library.id) || testSection")
+        XCTAssertEqual(viewModel.displaySections.getOrNil(0)?.id, "Author: testSection")
     }
     
     func testTapBook() throws {
@@ -114,14 +105,105 @@ class SectionShelfViewModelTests: XCTestCase {
     func testSelectAllAndClear() throws {
         let item = ShelfBookItem(id: "book-1", title: "Book 1", coverURL: "", progress: 50, status: .ready)
         let section = ShelfSectionItem(id: "section-1", title: "Section 1", books: [item])
-        
+
         viewModel.displaySections = [section]
-        
+
         viewModel.selectAllBooks()
         XCTAssertEqual(viewModel.selectionState.selectedBookIds.count, 1)
         XCTAssertTrue(viewModel.selectionState.selectedBookIds.contains("book-1"))
-        
+
         viewModel.clearSelection()
         XCTAssertEqual(viewModel.selectionState.selectedBookIds.count, 0)
+    }
+
+    // MARK: - Cross-library section + book-level library filter
+
+    private func makeLibrary(serverName: String, libraryKey: String, libraryName: String) -> (server: CalibreServer, library: CalibreLibrary) {
+        let server = CalibreServer(uuid: UUID(), name: serverName, baseUrl: "http://localhost/\(serverName)", hasPublicUrl: false, publicUrl: "", hasAuth: false, username: "", password: "")
+        let library = CalibreLibrary(server: server, key: libraryKey, name: libraryName)
+        return (server, library)
+    }
+
+    func testCrossLibraryAuthorSectionShownWithoutFilter() {
+        let (_, lib1) = makeLibrary(serverName: "S1", libraryKey: "k1", libraryName: "Library 1")
+        let (_, lib2) = makeLibrary(serverName: "S2", libraryKey: "k2", libraryName: "Library 2")
+        mockAppContainer.calibreLibraries[lib1.id] = lib1
+        mockAppContainer.calibreLibraries[lib2.id] = lib2
+
+        let book1 = ShelfBookItem(id: "b1", title: "Book 1", coverURL: "", progress: 0, status: .ready, libraryId: lib1.id)
+        let book2 = ShelfBookItem(id: "b2", title: "Book 2", coverURL: "", progress: 0, status: .ready, libraryId: lib2.id)
+        let section = ShelfSectionItem(id: "Author: Ursula K. Le Guin", title: "Author: Ursula K. Le Guin", books: [book1, book2])
+
+        mockAppContainer.discoverShelfItemsSubject.send([section])
+
+        XCTAssertEqual(viewModel.displaySections.count, 1)
+        XCTAssertEqual(viewModel.displaySections.getOrNil(0)?.books.count, 2)
+        XCTAssertEqual(viewModel.libraryFilters.count, 2)
+        XCTAssertTrue(viewModel.pickedLibraries.isEmpty)
+    }
+
+    func testLibraryFilterFiltersBooksNotSections() {
+        let (_, lib1) = makeLibrary(serverName: "S1", libraryKey: "k1", libraryName: "Library 1")
+        let (_, lib2) = makeLibrary(serverName: "S2", libraryKey: "k2", libraryName: "Library 2")
+        mockAppContainer.calibreLibraries[lib1.id] = lib1
+        mockAppContainer.calibreLibraries[lib2.id] = lib2
+
+        let book1 = ShelfBookItem(id: "b1", title: "Book 1", coverURL: "", progress: 0, status: .ready, libraryId: lib1.id)
+        let book2 = ShelfBookItem(id: "b2", title: "Book 2", coverURL: "", progress: 0, status: .ready, libraryId: lib2.id)
+        let section = ShelfSectionItem(id: "Author: Ursula K. Le Guin", title: "Author: Ursula K. Le Guin", books: [book1, book2])
+
+        mockAppContainer.discoverShelfItemsSubject.send([section])
+        viewModel.toggleLibraryFilter(libraryId: lib1.id)
+
+        XCTAssertEqual(viewModel.displaySections.count, 1)
+        XCTAssertEqual(viewModel.displaySections.getOrNil(0)?.books.count, 1)
+        XCTAssertEqual(viewModel.displaySections.getOrNil(0)?.books.getOrNil(0)?.id, "b1")
+        XCTAssertEqual(viewModel.displaySections.getOrNil(0)?.id, "Author: Ursula K. Le Guin")
+    }
+
+    func testEmptySectionAfterFilterHidden() {
+        let (_, lib1) = makeLibrary(serverName: "S1", libraryKey: "k1", libraryName: "Library 1")
+        let (_, lib2) = makeLibrary(serverName: "S2", libraryKey: "k2", libraryName: "Library 2")
+        mockAppContainer.calibreLibraries[lib1.id] = lib1
+        mockAppContainer.calibreLibraries[lib2.id] = lib2
+
+        let book1 = ShelfBookItem(id: "b1", title: "Book 1", coverURL: "", progress: 0, status: .ready, libraryId: lib1.id)
+        let section = ShelfSectionItem(id: "Author: One", title: "Author: One", books: [book1])
+
+        mockAppContainer.discoverShelfItemsSubject.send([section])
+        viewModel.toggleLibraryFilter(libraryId: lib2.id)
+
+        XCTAssertEqual(viewModel.displaySections.count, 0)
+    }
+
+    func testLibraryFiltersAggregatedFromBookLevelLibraryId() {
+        let (_, lib1) = makeLibrary(serverName: "S1", libraryKey: "k1", libraryName: "Library 1")
+        let (_, lib2) = makeLibrary(serverName: "S2", libraryKey: "k2", libraryName: "Library 2")
+        mockAppContainer.calibreLibraries[lib1.id] = lib1
+        mockAppContainer.calibreLibraries[lib2.id] = lib2
+
+        let book1 = ShelfBookItem(id: "b1", title: "Book 1", coverURL: "", progress: 0, status: .ready, libraryId: lib1.id)
+        let book2 = ShelfBookItem(id: "b2", title: "Book 2", coverURL: "", progress: 0, status: .ready, libraryId: lib2.id)
+        let s1 = ShelfSectionItem(id: "Author: A", title: "Author: A", books: [book1])
+        let s2 = ShelfSectionItem(id: "Author: B", title: "Author: B", books: [book2])
+
+        mockAppContainer.discoverShelfItemsSubject.send([s1, s2])
+
+        let filterIds = Set(viewModel.libraryFilters.map { $0.id })
+        XCTAssertEqual(viewModel.libraryFilters.count, 2)
+        XCTAssertTrue(filterIds.contains(lib1.id))
+        XCTAssertTrue(filterIds.contains(lib2.id))
+    }
+
+    func testBootstrapIfDatabaseReadyIdempotent() {
+        // Without a database-ready container, bootstrap is a no-op.
+        let freshContainer = MockAppContainerFactory.makeContainer(testName: "SectionShelfViewModelTests-bootstrap")
+        let freshVM = SectionShelfViewModel(container: freshContainer)
+
+        // Calling twice should not crash and should not double-fill sections.
+        freshVM.bootstrapIfDatabaseReady()
+        freshVM.bootstrapIfDatabaseReady()
+
+        XCTAssertEqual(freshVM.displaySections.count, 0)
     }
 }

--- a/YetAnotherEBookReaderTests/ShelfDisplayModelsTests.swift
+++ b/YetAnotherEBookReaderTests/ShelfDisplayModelsTests.swift
@@ -143,5 +143,30 @@ import Combine
         XCTAssertEqual(section.title, "Author: Ursula K. Le Guin")
         XCTAssertEqual(section.books.count, 1)
         XCTAssertEqual(section.books.getOrNil(0)?.libraryId, library.id)
+        XCTAssertEqual(section.books.getOrNil(0)?.id, book.inShelfId)
+    }
+
+    func testBuildShelfSectionItemUsesInShelfIdFormat() {
+        // The book id must match the CalibreBookRealm primary key format
+        // ("id^libraryName@serverUUID") so that downstream consumers
+        // (bookExists, getBook, BookDetailView) can find the book.
+        // Using the bare Int32 id would cause `bookExists(forPrimaryKey:)`
+        // to return false and BookDetailView to stay on "Loading...".
+        let mockAppContainer = MockAppContainerFactory.makeContainer(testName: "ShelfDisplayModelsTests-buildShelf-format")
+        let shelfDataModel = mockAppContainer.shelfDataModel
+
+        let server = CalibreServer(uuid: UUID(), name: "S", baseUrl: "http://localhost", hasPublicUrl: false, publicUrl: "", hasAuth: false, username: "", password: "")
+        let library = CalibreLibrary(server: server, key: "k", name: "My Library")
+        let book = CalibreBook(id: 42, library: library)
+
+        let category = YabrShelfDataModel.CategoryObject(type: .Author, category: "Some Author")
+        category.unifiedSearchResult = UnifiedSearchResult(books: [book])
+
+        let section = shelfDataModel.buildShelfSectionItem(category: category)
+        let bookId = section.books.getOrNil(0)?.id
+
+        XCTAssertNotEqual(bookId, "42", "Bare Int32 id is not the CalibreBookRealm primary key")
+        XCTAssertEqual(bookId, "42^My Library@\(server.uuid.uuidString)")
+        XCTAssertEqual(bookId, book.inShelfId)
     }
 }

--- a/YetAnotherEBookReaderTests/ShelfDisplayModelsTests.swift
+++ b/YetAnotherEBookReaderTests/ShelfDisplayModelsTests.swift
@@ -36,27 +36,31 @@ import Combine
     
     func testSectionShelfViewModelMappingAndFilters() {
         let mockAppContainer = MockAppContainerFactory.makeContainer(testName: "ShelfDisplayModelsTests")
-        
+
         // Setup library config in mockAppContainer
         let uuid = UUID()
         let mockServer = CalibreServer(uuid: uuid, name: "Test Server", baseUrl: "http://localhost", hasPublicUrl: false, publicUrl: "", hasAuth: false, username: "", password: "")
         let mockLibrary = CalibreLibrary(server: mockServer, key: "testLibrary", name: "Test Library")
         let libraryId = mockLibrary.id
         mockAppContainer.calibreLibraries[libraryId] = mockLibrary
-        
+
         let viewModel = SectionShelfViewModel(container: mockAppContainer)
-        
+
         let bookItem = ShelfBookItem(
             id: "test-id",
             title: "Test Title",
             coverURL: "https://example.com/cover.png",
             progress: 0,
-            status: .ready
+            status: .ready,
+            libraryId: libraryId
         )
-        
+
+        // Cross-library author section: the section id is "Author: <name>"
+        // and the per-book libraryId carries the library ownership. The
+        // view model no longer parses the section id to decide visibility.
         let section = ShelfSectionItem(
-            id: libraryId + " || testSection",
-            title: "testSection",
+            id: "Author: testSection",
+            title: "Author: testSection",
             books: [bookItem]
         )
 
@@ -81,11 +85,63 @@ import Combine
         XCTAssertTrue(viewModel.pickedLibraries.contains(libraryId))
         // toggleLibraryFilter calls applyFiltering synchronously.
         XCTAssertTrue(viewModel.libraryFilters.getOrNil(0)?.isSelected ?? false)
+        // Section still visible (1 book matches the picked library).
+        XCTAssertEqual(viewModel.displaySections.count, 1)
+        XCTAssertEqual(viewModel.displaySections.getOrNil(0)?.books.count, 1)
 
         // Test resetting filters
         viewModel.resetLibraryFilters()
         XCTAssertTrue(viewModel.pickedLibraries.isEmpty)
         // resetLibraryFilters calls applyFiltering synchronously.
         XCTAssertFalse(viewModel.libraryFilters.getOrNil(0)?.isSelected ?? true)
+        XCTAssertEqual(viewModel.displaySections.count, 1)
+    }
+
+    // MARK: - ShelfBookItem libraryId
+
+    func testShelfBookItemDefaultLibraryIdNil() {
+        // Recent shelf still constructs ShelfBookItem with the original
+        // 5-argument call site; libraryId must default to nil.
+        let item = ShelfBookItem(
+            id: "recent-1",
+            title: "Recent Book",
+            coverURL: "",
+            progress: 0,
+            status: .local
+        )
+        XCTAssertNil(item.libraryId)
+    }
+
+    func testShelfBookItemLibraryIdRoundTrips() {
+        let item = ShelfBookItem(
+            id: "disc-1",
+            title: "Discover Book",
+            coverURL: "",
+            progress: 0,
+            status: .ready,
+            libraryId: "lib-abc"
+        )
+        XCTAssertEqual(item.libraryId, "lib-abc")
+    }
+
+    // MARK: - YabrShelfDataModel.buildShelfSectionItem
+
+    func testBuildShelfSectionItemPopulatesLibraryId() {
+        let mockAppContainer = MockAppContainerFactory.makeContainer(testName: "ShelfDisplayModelsTests-buildShelf")
+        let shelfDataModel = mockAppContainer.shelfDataModel
+
+        let server = CalibreServer(uuid: UUID(), name: "S", baseUrl: "http://localhost", hasPublicUrl: false, publicUrl: "", hasAuth: false, username: "", password: "")
+        let library = CalibreLibrary(server: server, key: "k", name: "L")
+        let book = CalibreBook(id: 42, library: library)
+
+        let category = YabrShelfDataModel.CategoryObject(type: .Author, category: "Ursula K. Le Guin")
+        category.unifiedSearchResult = UnifiedSearchResult(books: [book])
+
+        let section = shelfDataModel.buildShelfSectionItem(category: category)
+
+        XCTAssertEqual(section.id, "Author: Ursula K. Le Guin")
+        XCTAssertEqual(section.title, "Author: Ursula K. Le Guin")
+        XCTAssertEqual(section.books.count, 1)
+        XCTAssertEqual(section.books.getOrNil(0)?.libraryId, library.id)
     }
 }


### PR DESCRIPTION
## Summary
- Store the originating `libraryId` on discover shelf book items so section filtering no longer depends on parsing section IDs
- Filter Discover shelf visibility at the book level, which preserves cross-library author sections while still honoring library filters
- Bootstrap the Discover shelf view model when the view appears to cover direct tab entry before database-ready signals arrive
- Update tests to cover cross-library sections, empty filtered sections, idempotent bootstrap, and `ShelfBookItem`/`YabrShelfDataModel` mapping

## Testing
- Updated unit test coverage for Discover shelf filtering and shelf item mapping
- Not run (not requested)